### PR TITLE
OSD-11906 Update with needed Route53 permissions for local dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,6 @@ testbin/*
 *~
 
 # Terraform
+terraform.*
 *.terraform
 *.terraform.*

--- a/dev/README.md
+++ b/dev/README.md
@@ -18,7 +18,7 @@
     ```bash
     # Admin-level, for when you don't want to deal with a least-privilege IAM policy
     AWS_ACCOUNT_ID=
-    export $(osdctl account cli -i ${AWS_ACCOUNT_ID} -p osd-staging-2 -o env | xargs) 
+    export $(osdctl account cli -i ${AWS_ACCOUNT_ID} -p osd-staging-2 -o env | xargs)
     ```
 
     ```bash


### PR DESCRIPTION
Three additional permissions are needed for the operator to manage Route53 Hosted Zone records

```yaml
"route53:ChangeResourceRecordSets",
"route53:ListHostedZonesByName",
"route53:ListResourceRecordSets"
```

https://github.com/openshift/aws-vpce-operator/blob/main/pkg/aws_client/route53_hosted_zone.go