### PR TITLE
Dockerfile, FIPS, and config.go fixes for boilerplate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+FIPS_ENABLED=true
+
 include boilerplate/generated-includes.mk
 
 SHELL := /usr/bin/env bash

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,26 +1,27 @@
 FROM quay.io/app-sre/boilerplate:image-v2.3.2 AS builder
 
-WORKDIR /workspace
-# Copy the Go Modules manifests
+RUN mkdir -p /workdir
+WORKDIR /workdir
 COPY go.mod go.mod
 COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
 RUN go mod download
+COPY . .
+RUN make go-build
 
-# Copy the go source
-COPY main.go main.go
-COPY api/ api/
-COPY controllers/ controllers/
+###
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
-# Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+ENV USER_UID=1001 \
+    USER_NAME=aws-vpce-operator
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
-WORKDIR /
-COPY --from=builder /workspace/manager .
-USER 65532:65532
+COPY --from=builder /workdir/build/_output/bin/* /usr/local/bin/
 
-ENTRYPOINT ["/manager"]
+COPY build/bin /usr/local/bin
+RUN /usr/local/bin/user_setup
+
+ENTRYPOINT ["/usr/local/bin/entrypoint"]
+
+USER ${USER_UID}
+
+LABEL io.openshift.managed.name="aws-vpce-operator" \
+      io.openshift.managed.description="AWS VPCE Operator"

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+const (
+	OperatorName      string = "aws-vpce-operator"
+	OperatorNamespace string = "openshift-aws-vpce-operator"
+)

--- a/fips.go
+++ b/fips.go
@@ -1,0 +1,15 @@
+// +build fips_enabled
+
+// BOILERPLATE GENERATED -- DO NOT EDIT
+// Run 'make ensure-fips' to regenerate
+
+package main
+
+import (
+	_ "crypto/tls/fipsonly"
+	"fmt"
+)
+
+func init() {
+	fmt.Println("***** Starting with FIPS crypto enabled *****")
+}


### PR DESCRIPTION
Moving to a Dockerfile like all the other operators instead of the default provided one.