### PR TITLE
OSD-11517 Add missing shell scripts for the Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ testbin/*
 !vendor/**/zz_generated.*
 
 # editor and IDE paraphernalia
+.docker
 .venv
 .idea
 *.swp

--- a/build/bin/entrypoint
+++ b/build/bin/entrypoint
@@ -1,0 +1,12 @@
+#!/bin/sh -e
+
+# This is documented here:
+# https://docs.openshift.com/container-platform/4.10/openshift_images/create-images.html#images-create-guide-openshift_create-images
+
+if ! whoami &>/dev/null; then
+  if [ -w /etc/passwd ]; then
+    echo "${USER_NAME:-aws-vpce-operator}:x:$(id -u):$(id -g):${USER_NAME:-aws-vpce-operator} user:${HOME}:/sbin/nologin" >> /etc/passwd
+  fi
+fi
+
+exec ${OPERATOR} $@

--- a/build/bin/user_setup
+++ b/build/bin/user_setup
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -x
+
+# ensure $HOME exists and is accessible by group 0 (we don't know what the runtime UID will be)
+mkdir -p ${HOME}
+chown ${USER_UID}:0 ${HOME}
+chmod ug+rwx ${HOME}
+
+# runtime user will need to be able to self-insert in /etc/passwd
+chmod g+rw /etc/passwd
+
+# no need for this script to remain in the image after running
+rm $0


### PR DESCRIPTION
Needed in https://github.com/openshift/aws-vpce-operator/blob/main/build/Dockerfile#L19, seems common to all operators - not sure why it wasn't part of boilerplating the operator...