### PR TITLE
OSD-11517 Pull out ClusterInfo struct and initialization to improve readability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,19 @@ SHELL := /usr/bin/env bash
 .PHONY: boilerplate-update
 boilerplate-update:
 	@boilerplate/update
+
+.PHONY: run
+run:
+	go run ./main.go
+
+ifndef ignore-not-found
+  ignore-not-found = false
+endif
+
+.PHONY: install
+install: ## Install CRDs into the K8s cluster specified in ~/.kube/config.
+	oc apply -f ./deploy/crds/
+
+.PHONY: uninstall
+uninstall: ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
+	oc delete --ignore-not-found=$(ignore-not-found) -f ./deploy/crds/

--- a/controllers/vpcendpoint/cleanup.go
+++ b/controllers/vpcendpoint/cleanup.go
@@ -32,7 +32,7 @@ func (r *VpcEndpointReconciler) deleteAWSResources(ctx context.Context, resource
 			return err
 		}
 
-		hostedZone, err := r.AWSClient.GetDefaultPrivateHostedZoneId(r.DomainName)
+		hostedZone, err := r.AWSClient.GetDefaultPrivateHostedZoneId(r.ClusterInfo.DomainName)
 		if err != nil {
 			return err
 		}

--- a/controllers/vpcendpoint/helpers.go
+++ b/controllers/vpcendpoint/helpers.go
@@ -17,10 +17,68 @@ limitations under the License.
 package vpcendpoint
 
 import (
+	"context"
 	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/openshift/aws-vpce-operator/api/v1alpha1"
+	"github.com/openshift/aws-vpce-operator/pkg/aws_client"
+	"github.com/openshift/aws-vpce-operator/pkg/dnses"
+	"github.com/openshift/aws-vpce-operator/pkg/infrastructures"
+	"github.com/openshift/aws-vpce-operator/pkg/util"
 )
+
+// parseClusterInfo fills in the ClusterInfo struct values inside the VpcEndpointReconciler
+func (r *VpcEndpointReconciler) parseClusterInfo(ctx context.Context) error {
+	r.ClusterInfo = new(ClusterInfo)
+
+	region, err := infrastructures.GetAWSRegion(ctx, r.Client)
+	if err != nil {
+		return err
+	}
+	r.ClusterInfo.Region = region
+	r.Log.V(1).Info("Parsed region from infrastructure", "region", region)
+
+	sess, err := session.NewSession(&aws.Config{
+		Region: &region,
+	})
+	if err != nil {
+		return err
+	}
+	r.AWSClient = aws_client.New(sess)
+
+	infraName, err := infrastructures.GetInfrastructureName(ctx, r.Client)
+	if err != nil {
+		return err
+	}
+	r.ClusterInfo.InfraName = infraName
+	r.Log.V(1).Info("Found infrastructure name:", "name", infraName)
+
+	clusterTag, err := util.GetClusterTagKey(infraName)
+	if err != nil {
+		return err
+	}
+	r.ClusterInfo.ClusterTag = clusterTag
+	r.Log.V(1).Info("Found cluster tag:", "clusterTag", clusterTag)
+
+	vpcId, err := r.AWSClient.GetVPCId(clusterTag)
+	if err != nil {
+		return err
+	}
+	r.ClusterInfo.VpcId = vpcId
+	r.Log.V(1).Info("Found vpc id:", "vpcId", vpcId)
+
+	domainName, err := dnses.GetPrivateHostedZoneDomainName(ctx, r.Client)
+	if err != nil {
+		return err
+	}
+	r.ClusterInfo.DomainName = domainName
+	r.Log.V(1).Info("Found domain name:", "domainName", domainName)
+
+	return nil
+}
 
 func (r *VpcEndpointReconciler) defaultResourceRecord(resource *v1alpha1.VpcEndpoint) (*route53.ResourceRecord, error) {
 	if resource.Status.VPCEndpointId == "" {

--- a/dev/README.md
+++ b/dev/README.md
@@ -9,7 +9,7 @@
 1. Applying manifests to the running ROSA cluster
 
     ```bash
-    make
+    ./boilerplate/_lib/container-make generate
     make install
     ```
 

--- a/pkg/dnses/main.go
+++ b/pkg/dnses/main.go
@@ -18,6 +18,7 @@ package dnses
 
 import (
 	"context"
+
 	configv1 "github.com/openshift/api/config/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )


### PR DESCRIPTION
Documenting and pulling out the initialization of the `ClusterInfo` struct so that the `Reconcile` function is more clearly:
* initialize
* check for deletion/delete if needed
* create/update if needed

Adding back useful "default" operator-sdk make targets that got wiped out by boilerplate

