### PR TITLE
Standardize request logging with RFC3339 timestamps

### DIFF
--- a/controllers/vpcendpoint/vpcendpoint_controller.go
+++ b/controllers/vpcendpoint/vpcendpoint_controller.go
@@ -24,7 +24,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/go-logr/logr"
@@ -69,7 +68,13 @@ type ClusterInfo struct {
 //+kubebuilder:rbac:groups=config.openshift.io,resources=dnses,verbs=get
 
 func (r *VpcEndpointReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Log = log.FromContext(ctx)
+	reqLogger, err := defaultLogger()
+	if err != nil {
+		// Shouldn't happen, but if it does, we can't log
+		return ctrl.Result{}, err
+	}
+
+	r.Log = reqLogger.WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name)
 
 	if err := r.parseClusterInfo(ctx); err != nil {
 		return ctrl.Result{}, err

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,10 @@ go 1.17
 require (
 	github.com/aws/aws-sdk-go v1.44.27
 	github.com/go-logr/logr v1.2.0
+	github.com/go-logr/zapr v1.2.0
 	github.com/openshift/api v0.0.0-20220119132100-58db72a40994
 	github.com/stretchr/testify v1.7.0
+	go.uber.org/zap v1.19.1
 	k8s.io/apimachinery v0.23.0
 	k8s.io/client-go v0.23.0
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65
@@ -30,7 +32,6 @@ require (
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/form3tech-oss/jwt-go v3.2.3+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
-	github.com/go-logr/zapr v1.2.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
 	github.com/go-openapi/swag v0.19.14 // indirect
@@ -58,7 +59,6 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
-	go.uber.org/zap v1.19.1 // indirect
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect


### PR DESCRIPTION
Switch to adding `Request.Namespace` and `Request.Name` and use nicer timestamps, e.g. past:
```
1.6547026149781811e+09	DEBUG	controller.vpcendpoint	Searching for security group by ID	{"reconciler group": "pso.example.com", "reconciler kind": "VpcEndpoint", "name": "demo", "namespace": "demo", "id": "sg-0bc3b12b1da744606"}
```

present:
```json
{"level":"info","ts":"2022-06-08T15:15:35-04:00","logger":"vpcendpoint","caller":"vpcendpoint/cleanup.go:67","msg":"Deleting AWS resources","Request.Namespace":"demo","Request.Name":"demo","SecurityGroup":"sg-0bc3b12b1da744606"}
```