### PR TITLE
OSD-11948 Add unit tests for AWS subnet functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # aws-vpce-operator (AVO)
 
+[![codecov](https://codecov.io/gh/openshift/aws-vpce-operator/branch/main/graph/badge.svg)](https://codecov.io/gh/openshift/aws-vpce-operator)

--- a/pkg/aws_client/client_test.go
+++ b/pkg/aws_client/client_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws_client
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+const (
+	mockClusterTag      = "kubernetes.io/cluster/mock-12345"
+	mockPublicSubnetId  = "subnet-pub12345"
+	mockPrivateSubnetId = "subnet-priv12345"
+	mockVpcId           = "vpc-12345"
+)
+
+var mockSubnets = []*ec2.Subnet{
+	{
+		SubnetId: aws.String(mockPrivateSubnetId),
+		Tags: []*ec2.Tag{
+			{
+				Key:   aws.String(privateSubnetTagKey),
+				Value: nil,
+			},
+			{
+				Key:   aws.String(mockClusterTag),
+				Value: aws.String("shared"),
+			},
+		},
+		VpcId: aws.String(mockVpcId),
+	},
+	{
+		SubnetId: aws.String(mockPublicSubnetId),
+		Tags: []*ec2.Tag{
+			{
+				Key:   aws.String(publicSubnetTagKey),
+				Value: nil,
+			},
+			{
+				Key:   aws.String(mockClusterTag),
+				Value: aws.String("shared"),
+			},
+		},
+		VpcId: aws.String(mockVpcId),
+	},
+}

--- a/pkg/aws_client/subnet_test.go
+++ b/pkg/aws_client/subnet_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws_client
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockedDescribeSubnets struct {
+	ec2iface.EC2API
+
+	Subnets []*ec2.Subnet
+	Resp    ec2.DescribeSubnetsOutput
+}
+
+func newMockedDescribeSubnets() *mockedDescribeSubnets {
+	return &mockedDescribeSubnets{
+		Subnets: mockSubnets,
+	}
+}
+
+func (m *mockedDescribeSubnets) DescribeSubnets(input *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
+	tagKeys := map[string]bool{}
+	for _, filter := range input.Filters {
+		for _, tagKey := range filter.Values {
+			tagKeys[*tagKey] = true
+		}
+	}
+
+	for _, subnet := range m.Subnets {
+		foundTags := 0
+		for tagKey := range tagKeys {
+			for _, tag := range subnet.Tags {
+				if *tag.Key == tagKey {
+					foundTags++
+					break
+				}
+			}
+			if foundTags == len(tagKeys) {
+				return &ec2.DescribeSubnetsOutput{
+					Subnets: []*ec2.Subnet{subnet},
+				}, nil
+			}
+		}
+	}
+
+	return &ec2.DescribeSubnetsOutput{}, nil
+}
+
+func TestAWSClient_DescribeSubnets(t *testing.T) {
+	tests := []struct {
+		clusterTag        string
+		expectedPrivateId string
+		expectedPublicId  string
+		expectedVpcId     string
+		expectErr         bool
+	}{
+		{
+			clusterTag:        mockClusterTag,
+			expectedPrivateId: mockPrivateSubnetId,
+			expectedPublicId:  mockPublicSubnetId,
+			expectedVpcId:     mockVpcId,
+			expectErr:         false,
+		},
+	}
+
+	client := &AWSClient{
+		EC2Client: newMockedDescribeSubnets(),
+	}
+
+	for _, test := range tests {
+		actualPrivate, err := client.DescribePrivateSubnets(test.clusterTag)
+		if test.expectErr {
+			assert.NotNil(t, err)
+		} else {
+			assert.Nil(t, err)
+			assert.Equal(t, len(actualPrivate.Subnets), 1)
+			assert.Equal(t, test.expectedPrivateId, *actualPrivate.Subnets[0].SubnetId)
+		}
+
+		actualPublic, err := client.DescribePublicSubnets(test.clusterTag)
+		if test.expectErr {
+			assert.NotNil(t, err)
+		} else {
+			assert.Nil(t, err)
+			assert.Equal(t, len(actualPublic.Subnets), 1)
+			assert.Equal(t, test.expectedPublicId, *actualPublic.Subnets[0].SubnetId)
+		}
+
+		actualVpcId, err := client.GetVPCId(test.clusterTag)
+		if test.expectErr {
+			assert.NotNil(t, err)
+		} else {
+			assert.Nil(t, err)
+			assert.Equal(t, test.expectedVpcId, actualVpcId)
+		}
+	}
+}


### PR DESCRIPTION
A mocked `DescribeSubnets` was all that was needed

Also showing off our whopping 11% test coverage ⭐ 