### PR TITLE
OSD-11948 Add unit tests for AWS VPC Endpoint functions

### DIFF
--- a/pkg/aws_client/client_test.go
+++ b/pkg/aws_client/client_test.go
@@ -19,13 +19,16 @@ package aws_client
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 )
 
 const (
-	mockClusterTag      = "kubernetes.io/cluster/mock-12345"
-	mockPublicSubnetId  = "subnet-pub12345"
-	mockPrivateSubnetId = "subnet-priv12345"
-	mockVpcId           = "vpc-12345"
+	mockClusterTag             = "kubernetes.io/cluster/mock-12345"
+	mockPublicSubnetId         = "subnet-pub12345"
+	mockPrivateSubnetId        = "subnet-priv12345"
+	mockVpcId                  = "vpc-12345"
+	mockVpcEndpointId          = "vpce-12345"
+	mockVpcEndpointServiceName = "com.amazonaws.vpce.service.mock-12345"
 )
 
 var mockSubnets = []*ec2.Subnet{
@@ -57,4 +60,16 @@ var mockSubnets = []*ec2.Subnet{
 		},
 		VpcId: aws.String(mockVpcId),
 	},
+}
+
+type mockedEC2 struct {
+	ec2iface.EC2API
+
+	Subnets []*ec2.Subnet
+}
+
+func newMockedEC2() *mockedEC2 {
+	return &mockedEC2{
+		Subnets: mockSubnets,
+	}
 }

--- a/pkg/aws_client/subnet_test.go
+++ b/pkg/aws_client/subnet_test.go
@@ -20,24 +20,10 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/stretchr/testify/assert"
 )
 
-type mockedDescribeSubnets struct {
-	ec2iface.EC2API
-
-	Subnets []*ec2.Subnet
-	Resp    ec2.DescribeSubnetsOutput
-}
-
-func newMockedDescribeSubnets() *mockedDescribeSubnets {
-	return &mockedDescribeSubnets{
-		Subnets: mockSubnets,
-	}
-}
-
-func (m *mockedDescribeSubnets) DescribeSubnets(input *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
+func (m *mockedEC2) DescribeSubnets(input *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
 	tagKeys := map[string]bool{}
 	for _, filter := range input.Filters {
 		for _, tagKey := range filter.Values {
@@ -83,7 +69,7 @@ func TestAWSClient_DescribeSubnets(t *testing.T) {
 	}
 
 	client := &AWSClient{
-		EC2Client: newMockedDescribeSubnets(),
+		EC2Client: newMockedEC2(),
 	}
 
 	for _, test := range tests {

--- a/pkg/aws_client/vpc_endpoint_test.go
+++ b/pkg/aws_client/vpc_endpoint_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws_client
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/stretchr/testify/assert"
+)
+
+func (m *mockedEC2) DescribeVpcEndpoints(input *ec2.DescribeVpcEndpointsInput) (*ec2.DescribeVpcEndpointsOutput, error) {
+	// Mock a VPC Endpoint if an ID is supplied
+	if len(input.VpcEndpointIds) > 0 {
+		return &ec2.DescribeVpcEndpointsOutput{
+			VpcEndpoints: []*ec2.VpcEndpoint{
+				{
+					VpcEndpointId: input.VpcEndpointIds[0],
+				},
+			},
+		}, nil
+	}
+
+	// Mock a VPC Endpoint with a specified tag-key
+	if len(input.Filters) > 0 {
+		for _, filter := range input.Filters {
+			if *filter.Name == "tag-key" {
+				return &ec2.DescribeVpcEndpointsOutput{
+					VpcEndpoints: []*ec2.VpcEndpoint{
+						{
+							Tags: []*ec2.Tag{
+								{
+									Key:   filter.Values[0],
+									Value: nil,
+								},
+							},
+						},
+					},
+				}, nil
+			}
+		}
+	}
+
+	return &ec2.DescribeVpcEndpointsOutput{}, nil
+}
+
+func (m *mockedEC2) CreateVpcEndpoint(input *ec2.CreateVpcEndpointInput) (*ec2.CreateVpcEndpointOutput, error) {
+	return &ec2.CreateVpcEndpointOutput{
+		VpcEndpoint: &ec2.VpcEndpoint{
+			VpcEndpointId: aws.String(mockVpcEndpointId),
+		},
+	}, nil
+}
+
+func (m *mockedEC2) DeleteVpcEndpoints(input *ec2.DeleteVpcEndpointsInput) (*ec2.DeleteVpcEndpointsOutput, error) {
+	return &ec2.DeleteVpcEndpointsOutput{}, nil
+}
+
+func TestAWSClient_DescribeSingleVPCEndpointById(t *testing.T) {
+	client := &AWSClient{
+		EC2Client: &mockedEC2{},
+	}
+
+	resp, err := client.DescribeSingleVPCEndpointById(mockVpcEndpointId)
+	assert.NoError(t, err)
+	assert.Equal(t, mockVpcEndpointId, *resp.VpcEndpoints[0].VpcEndpointId)
+}
+
+func TestAWSClient_FilterVPCEndpointByDefaultTags(t *testing.T) {
+	client := &AWSClient{
+		EC2Client: &mockedEC2{},
+	}
+
+	_, err := client.FilterVPCEndpointByDefaultTags(mockClusterTag)
+	assert.NoError(t, err)
+}
+
+func TestCreateDeleteVPCEndpoint(t *testing.T) {
+	client := &AWSClient{
+		EC2Client: &mockedEC2{},
+	}
+
+	resp, err := client.CreateDefaultInterfaceVPCEndpoint("name", mockVpcId, mockVpcEndpointServiceName, mockClusterTag)
+	assert.NoError(t, err)
+
+	_, err = client.DeleteVPCEndpoint(*resp.VpcEndpoint.VpcEndpointId)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
The unit testing march continues. In their current state, just like the subnet unit tests, they're not the most useful, but as we run into edge cases this provides a framework to add those in and validate functionality.