### PR TITLE
OSD-11948 Use mocks to test controller helper functions

### DIFF
--- a/controllers/vpcendpoint/helpers_test.go
+++ b/controllers/vpcendpoint/helpers_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vpcendpoint
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/openshift/aws-vpce-operator/api/v1alpha1"
+	"github.com/openshift/aws-vpce-operator/pkg/aws_client"
+	"github.com/openshift/aws-vpce-operator/pkg/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseClusterInfo(t *testing.T) {
+	mock, err := testutil.NewDefaultMock()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := &VpcEndpointReconciler{
+		Client: mock.Client,
+		Log:    testr.New(t),
+		Scheme: mock.Client.Scheme(),
+		AWSClient: &aws_client.AWSClient{
+			EC2Client: aws_client.NewMockedEC2WithSubnets(),
+		},
+		ClusterInfo: nil,
+	}
+
+	err = r.parseClusterInfo(context.TODO(), false)
+	assert.NoError(t, err)
+}
+
+func TestDefaultResourceRecord(t *testing.T) {
+	tests := []struct {
+		resource  *v1alpha1.VpcEndpoint
+		expectErr bool
+	}{
+		{
+			resource: &v1alpha1.VpcEndpoint{
+				Status: v1alpha1.VpcEndpointStatus{
+					VPCEndpointId: testutil.MockVpcEndpointId,
+				},
+			},
+			expectErr: false,
+		},
+		{
+			resource:  &v1alpha1.VpcEndpoint{},
+			expectErr: true,
+		},
+	}
+
+	mock, err := testutil.NewDefaultMock()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := &VpcEndpointReconciler{
+		Client: mock.Client,
+		Log:    testr.New(t),
+		Scheme: mock.Client.Scheme(),
+		AWSClient: &aws_client.AWSClient{
+			EC2Client:     aws_client.NewMockedEC2WithSubnets(),
+			Route53Client: aws_client.MockedRoute53{},
+		},
+		ClusterInfo: nil,
+	}
+
+	for _, test := range tests {
+		_, err = r.defaultResourceRecord(test.resource)
+		if test.expectErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+		}
+	}
+}

--- a/controllers/vpcendpoint/vpcendpoint_controller.go
+++ b/controllers/vpcendpoint/vpcendpoint_controller.go
@@ -76,7 +76,7 @@ func (r *VpcEndpointReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	r.Log = reqLogger.WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name)
 
-	if err := r.parseClusterInfo(ctx); err != nil {
+	if err := r.parseClusterInfo(ctx, true); err != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/aws/aws-sdk-go v1.44.27
-	github.com/go-logr/logr v1.2.0
+	github.com/go-logr/logr v1.2.3
 	github.com/go-logr/zapr v1.2.0
 	github.com/openshift/api v0.0.0-20220119132100-58db72a40994
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,9 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
-github.com/go-logr/logr v1.2.0 h1:QK40JKJyMdUDz+h+xvCsru/bJhvG0UxvePV0ufL/AcE=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
+github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/zapr v1.2.0 h1:n4JnPI1T3Qq1SFEi/F8rwLrZERp2bso19PJZDB9dayk=
 github.com/go-logr/zapr v1.2.0/go.mod h1:Qa4Bsj2Vb+FAVeAKsLD8RLQ+YRJB8YDmOAKxaBQf7Ro=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=

--- a/pkg/aws_client/mock.go
+++ b/pkg/aws_client/mock.go
@@ -25,23 +25,33 @@ import (
 )
 
 const (
-	mockClusterTag             = "kubernetes.io/cluster/mock-12345"
-	mockDomainName             = "mock-domain.com"
-	mockHostedZoneId           = "R53HZ12345"
-	mockPublicSubnetId         = "subnet-pub12345"
-	mockPrivateSubnetId        = "subnet-priv12345"
-	mockSecurityGroupId        = "sg-12345"
-	mockVpcId                  = "vpc-12345"
-	mockVpcEndpointId          = "vpce-12345"
-	mockVpcEndpointDnsName     = "vpce-12345.amazonaws.com"
-	mockVpcEndpointServiceName = "com.amazonaws.vpce.service.mock-12345"
+	MockClusterTag             = "kubernetes.io/cluster/mock-12345"
+	MockDomainName             = "mock-domain.com"
+	MockHostedZoneId           = "R53HZ12345"
+	MockPublicSubnetId         = "subnet-pub12345"
+	MockPrivateSubnetId        = "subnet-priv12345"
+	MockSecurityGroupId        = "sg-12345"
+	MockVpcId                  = "vpc-12345"
+	MockVpcEndpointId          = "vpce-12345"
+	MockVpcEndpointDnsName     = "vpce-12345.amazonaws.com"
+	MockVpcEndpointServiceName = "com.amazonaws.vpce.service.mock-12345"
 )
+
+type MockedEC2 struct {
+	ec2iface.EC2API
+
+	Subnets []*ec2.Subnet
+}
+
+type MockedRoute53 struct {
+	route53iface.Route53API
+}
 
 var mockResourceRecordSet = &route53.ResourceRecordSet{
 	Name: aws.String("mock"),
 	ResourceRecords: []*route53.ResourceRecord{
 		{
-			Value: aws.String(mockVpcEndpointDnsName),
+			Value: aws.String(MockVpcEndpointDnsName),
 		},
 	},
 	TTL:  aws.Int64(300),
@@ -50,47 +60,37 @@ var mockResourceRecordSet = &route53.ResourceRecordSet{
 
 var mockSubnets = []*ec2.Subnet{
 	{
-		SubnetId: aws.String(mockPrivateSubnetId),
+		SubnetId: aws.String(MockPrivateSubnetId),
 		Tags: []*ec2.Tag{
 			{
 				Key:   aws.String(privateSubnetTagKey),
 				Value: nil,
 			},
 			{
-				Key:   aws.String(mockClusterTag),
+				Key:   aws.String(MockClusterTag),
 				Value: aws.String("shared"),
 			},
 		},
-		VpcId: aws.String(mockVpcId),
+		VpcId: aws.String(MockVpcId),
 	},
 	{
-		SubnetId: aws.String(mockPublicSubnetId),
+		SubnetId: aws.String(MockPublicSubnetId),
 		Tags: []*ec2.Tag{
 			{
 				Key:   aws.String(publicSubnetTagKey),
 				Value: nil,
 			},
 			{
-				Key:   aws.String(mockClusterTag),
+				Key:   aws.String(MockClusterTag),
 				Value: aws.String("shared"),
 			},
 		},
-		VpcId: aws.String(mockVpcId),
+		VpcId: aws.String(MockVpcId),
 	},
 }
 
-type mockedEC2 struct {
-	ec2iface.EC2API
-
-	Subnets []*ec2.Subnet
-}
-
-type mockedRoute53 struct {
-	route53iface.Route53API
-}
-
-func newMockedEC2() *mockedEC2 {
-	return &mockedEC2{
+func newMockedEC2WithSubnets() *MockedEC2 {
+	return &MockedEC2{
 		Subnets: mockSubnets,
 	}
 }

--- a/pkg/aws_client/route53_hosted_zone_test.go
+++ b/pkg/aws_client/route53_hosted_zone_test.go
@@ -24,26 +24,26 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (m *mockedRoute53) ListHostedZonesByName(input *route53.ListHostedZonesByNameInput) (*route53.ListHostedZonesByNameOutput, error) {
+func (m *MockedRoute53) ListHostedZonesByName(input *route53.ListHostedZonesByNameInput) (*route53.ListHostedZonesByNameOutput, error) {
 	return &route53.ListHostedZonesByNameOutput{
 		DNSName:      input.DNSName,
-		HostedZoneId: aws.String(mockHostedZoneId),
+		HostedZoneId: aws.String(MockHostedZoneId),
 		HostedZones: []*route53.HostedZone{
 			{
-				Id:   aws.String(mockHostedZoneId),
+				Id:   aws.String(MockHostedZoneId),
 				Name: input.DNSName,
 			},
 		},
 	}, nil
 }
 
-func (m *mockedRoute53) ListResourceRecordSets(input *route53.ListResourceRecordSetsInput) (*route53.ListResourceRecordSetsOutput, error) {
+func (m *MockedRoute53) ListResourceRecordSets(input *route53.ListResourceRecordSetsInput) (*route53.ListResourceRecordSetsOutput, error) {
 	return &route53.ListResourceRecordSetsOutput{
 		ResourceRecordSets: []*route53.ResourceRecordSet{mockResourceRecordSet},
 	}, nil
 }
 
-func (m *mockedRoute53) ChangeResourceRecordSets(input *route53.ChangeResourceRecordSetsInput) (*route53.ChangeResourceRecordSetsOutput, error) {
+func (m *MockedRoute53) ChangeResourceRecordSets(input *route53.ChangeResourceRecordSetsInput) (*route53.ChangeResourceRecordSetsOutput, error) {
 	return &route53.ChangeResourceRecordSetsOutput{}, nil
 }
 
@@ -53,13 +53,13 @@ func TestAWSClient_GetDefaultPrivateHostedZoneId(t *testing.T) {
 		expectErr  bool
 	}{
 		{
-			domainName: mockDomainName,
+			domainName: MockDomainName,
 			expectErr:  false,
 		},
 	}
 
 	client := &AWSClient{
-		Route53Client: &mockedRoute53{},
+		Route53Client: &MockedRoute53{},
 	}
 
 	for _, test := range tests {
@@ -74,21 +74,21 @@ func TestAWSClient_GetDefaultPrivateHostedZoneId(t *testing.T) {
 
 func TestAWSClient_ListResourceRecordSets(t *testing.T) {
 	client := &AWSClient{
-		Route53Client: &mockedRoute53{},
+		Route53Client: &MockedRoute53{},
 	}
 
-	_, err := client.ListResourceRecordSets(mockHostedZoneId)
+	_, err := client.ListResourceRecordSets(MockHostedZoneId)
 	assert.NoError(t, err)
 }
 
 func TestAWSClient_UpsertDeleteResourceRecordSet(t *testing.T) {
 	client := &AWSClient{
-		Route53Client: &mockedRoute53{},
+		Route53Client: &MockedRoute53{},
 	}
 
-	_, err := client.UpsertResourceRecordSet(mockResourceRecordSet, mockHostedZoneId)
+	_, err := client.UpsertResourceRecordSet(mockResourceRecordSet, MockHostedZoneId)
 	assert.NoError(t, err)
 
-	_, err = client.DeleteResourceRecordSet(mockResourceRecordSet, mockHostedZoneId)
+	_, err = client.DeleteResourceRecordSet(mockResourceRecordSet, MockHostedZoneId)
 	assert.NoError(t, err)
 }

--- a/pkg/aws_client/route53_hosted_zone_test.go
+++ b/pkg/aws_client/route53_hosted_zone_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/openshift/aws-vpce-operator/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -53,7 +54,7 @@ func TestAWSClient_GetDefaultPrivateHostedZoneId(t *testing.T) {
 		expectErr  bool
 	}{
 		{
-			domainName: MockDomainName,
+			domainName: testutil.MockDomainName,
 			expectErr:  false,
 		},
 	}

--- a/pkg/aws_client/security_group_test.go
+++ b/pkg/aws_client/security_group_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (m *mockedEC2) DescribeSecurityGroups(input *ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
+func (m *MockedEC2) DescribeSecurityGroups(input *ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
 	if len(input.GroupIds) > 0 {
 		securityGroups := make([]*ec2.SecurityGroup, len(input.GroupIds))
 		for i, groupId := range input.GroupIds {
@@ -59,7 +59,7 @@ func (m *mockedEC2) DescribeSecurityGroups(input *ec2.DescribeSecurityGroupsInpu
 	return &ec2.DescribeSecurityGroupsOutput{}, nil
 }
 
-func (m *mockedEC2) AuthorizeSecurityGroupIngress(input *ec2.AuthorizeSecurityGroupIngressInput) (*ec2.AuthorizeSecurityGroupIngressOutput, error) {
+func (m *MockedEC2) AuthorizeSecurityGroupIngress(input *ec2.AuthorizeSecurityGroupIngressInput) (*ec2.AuthorizeSecurityGroupIngressOutput, error) {
 	rules := make([]*ec2.SecurityGroupRule, len(input.IpPermissions))
 	for i, permission := range input.IpPermissions {
 		rules[i] = &ec2.SecurityGroupRule{
@@ -74,7 +74,7 @@ func (m *mockedEC2) AuthorizeSecurityGroupIngress(input *ec2.AuthorizeSecurityGr
 	}, nil
 }
 
-func (m *mockedEC2) AuthorizeSecurityGroupEgress(input *ec2.AuthorizeSecurityGroupEgressInput) (*ec2.AuthorizeSecurityGroupEgressOutput, error) {
+func (m *MockedEC2) AuthorizeSecurityGroupEgress(input *ec2.AuthorizeSecurityGroupEgressInput) (*ec2.AuthorizeSecurityGroupEgressOutput, error) {
 	rules := make([]*ec2.SecurityGroupRule, len(input.IpPermissions))
 	for i, permission := range input.IpPermissions {
 		rules[i] = &ec2.SecurityGroupRule{
@@ -89,20 +89,20 @@ func (m *mockedEC2) AuthorizeSecurityGroupEgress(input *ec2.AuthorizeSecurityGro
 	}, nil
 }
 
-func (m *mockedEC2) CreateSecurityGroup(input *ec2.CreateSecurityGroupInput) (*ec2.CreateSecurityGroupOutput, error) {
+func (m *MockedEC2) CreateSecurityGroup(input *ec2.CreateSecurityGroupInput) (*ec2.CreateSecurityGroupOutput, error) {
 	if len(input.TagSpecifications) > 0 {
 		return &ec2.CreateSecurityGroupOutput{
-			GroupId: aws.String(mockSecurityGroupId),
+			GroupId: aws.String(MockSecurityGroupId),
 			Tags:    input.TagSpecifications[0].Tags,
 		}, nil
 	}
 
 	return &ec2.CreateSecurityGroupOutput{
-		GroupId: aws.String(mockSecurityGroupId),
+		GroupId: aws.String(MockSecurityGroupId),
 	}, nil
 }
 
-func (m *mockedEC2) DeleteSecurityGroup(input *ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error) {
+func (m *MockedEC2) DeleteSecurityGroup(input *ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error) {
 	return &ec2.DeleteSecurityGroupOutput{}, nil
 }
 
@@ -112,13 +112,13 @@ func TestAWSClient_FilterClusterNodeSecurityGroupsByDefaultTags(t *testing.T) {
 		expectErr bool
 	}{
 		{
-			tagKey:    mockClusterTag,
+			tagKey:    MockClusterTag,
 			expectErr: false,
 		},
 	}
 
 	client := &AWSClient{
-		EC2Client: &mockedEC2{},
+		EC2Client: &MockedEC2{},
 	}
 
 	for _, test := range tests {
@@ -137,13 +137,13 @@ func TestAWSClient_FilterSecurityGroupByDefaultTags(t *testing.T) {
 		expectErr bool
 	}{
 		{
-			tagKey:    mockClusterTag,
+			tagKey:    MockClusterTag,
 			expectErr: false,
 		},
 	}
 
 	client := &AWSClient{
-		EC2Client: &mockedEC2{},
+		EC2Client: &MockedEC2{},
 	}
 
 	for _, test := range tests {
@@ -162,13 +162,13 @@ func TestAWSClient_FilterSecurityGroupById(t *testing.T) {
 		expectErr bool
 	}{
 		{
-			groupId:   mockSecurityGroupId,
+			groupId:   MockSecurityGroupId,
 			expectErr: false,
 		},
 	}
 
 	client := &AWSClient{
-		EC2Client: &mockedEC2{},
+		EC2Client: &MockedEC2{},
 	}
 
 	for _, test := range tests {
@@ -191,7 +191,7 @@ func TestAWSClient_AuthorizeSecurityGroupRules(t *testing.T) {
 	}{
 		{
 			ingress: &ec2.AuthorizeSecurityGroupIngressInput{
-				GroupId: aws.String(mockSecurityGroupId),
+				GroupId: aws.String(MockSecurityGroupId),
 				IpPermissions: []*ec2.IpPermission{
 					{
 						FromPort:   aws.Int64(80),
@@ -201,7 +201,7 @@ func TestAWSClient_AuthorizeSecurityGroupRules(t *testing.T) {
 				},
 			},
 			egress: &ec2.AuthorizeSecurityGroupEgressInput{
-				GroupId: aws.String(mockSecurityGroupId),
+				GroupId: aws.String(MockSecurityGroupId),
 				IpPermissions: []*ec2.IpPermission{
 					{
 						FromPort:   aws.Int64(80),
@@ -216,7 +216,7 @@ func TestAWSClient_AuthorizeSecurityGroupRules(t *testing.T) {
 	}
 
 	client := &AWSClient{
-		EC2Client: &mockedEC2{},
+		EC2Client: &MockedEC2{},
 	}
 
 	for _, test := range tests {
@@ -232,10 +232,10 @@ func TestAWSClient_AuthorizeSecurityGroupRules(t *testing.T) {
 
 func TestAWSClient_CreateDeleteSecurityGroup(t *testing.T) {
 	client := &AWSClient{
-		EC2Client: &mockedEC2{},
+		EC2Client: &MockedEC2{},
 	}
 
-	resp, err := client.CreateSecurityGroup("name", mockVpcId, mockClusterTag)
+	resp, err := client.CreateSecurityGroup("name", MockVpcId, MockClusterTag)
 	assert.NoError(t, err)
 
 	_, err = client.DeleteSecurityGroup(*resp.GroupId)

--- a/pkg/aws_client/subnet_test.go
+++ b/pkg/aws_client/subnet_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (m *mockedEC2) DescribeSubnets(input *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
+func (m *MockedEC2) DescribeSubnets(input *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
 	tagKeys := map[string]bool{}
 	for _, filter := range input.Filters {
 		for _, tagKey := range filter.Values {
@@ -60,16 +60,16 @@ func TestAWSClient_DescribeSubnets(t *testing.T) {
 		expectErr         bool
 	}{
 		{
-			clusterTag:        mockClusterTag,
-			expectedPrivateId: mockPrivateSubnetId,
-			expectedPublicId:  mockPublicSubnetId,
-			expectedVpcId:     mockVpcId,
+			clusterTag:        MockClusterTag,
+			expectedPrivateId: MockPrivateSubnetId,
+			expectedPublicId:  MockPublicSubnetId,
+			expectedVpcId:     MockVpcId,
 			expectErr:         false,
 		},
 	}
 
 	client := &AWSClient{
-		EC2Client: newMockedEC2(),
+		EC2Client: newMockedEC2WithSubnets(),
 	}
 
 	for _, test := range tests {

--- a/pkg/aws_client/subnet_test.go
+++ b/pkg/aws_client/subnet_test.go
@@ -19,37 +19,8 @@ package aws_client
 import (
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/stretchr/testify/assert"
 )
-
-func (m *MockedEC2) DescribeSubnets(input *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
-	tagKeys := map[string]bool{}
-	for _, filter := range input.Filters {
-		for _, tagKey := range filter.Values {
-			tagKeys[*tagKey] = true
-		}
-	}
-
-	for _, subnet := range m.Subnets {
-		foundTags := 0
-		for tagKey := range tagKeys {
-			for _, tag := range subnet.Tags {
-				if *tag.Key == tagKey {
-					foundTags++
-					break
-				}
-			}
-			if foundTags == len(tagKeys) {
-				return &ec2.DescribeSubnetsOutput{
-					Subnets: []*ec2.Subnet{subnet},
-				}, nil
-			}
-		}
-	}
-
-	return &ec2.DescribeSubnetsOutput{}, nil
-}
 
 func TestAWSClient_DescribeSubnets(t *testing.T) {
 	tests := []struct {
@@ -69,7 +40,7 @@ func TestAWSClient_DescribeSubnets(t *testing.T) {
 	}
 
 	client := &AWSClient{
-		EC2Client: newMockedEC2WithSubnets(),
+		EC2Client: NewMockedEC2WithSubnets(),
 	}
 
 	for _, test := range tests {

--- a/pkg/aws_client/vpc_endpoint_test.go
+++ b/pkg/aws_client/vpc_endpoint_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (m *mockedEC2) DescribeVpcEndpoints(input *ec2.DescribeVpcEndpointsInput) (*ec2.DescribeVpcEndpointsOutput, error) {
+func (m *MockedEC2) DescribeVpcEndpoints(input *ec2.DescribeVpcEndpointsInput) (*ec2.DescribeVpcEndpointsOutput, error) {
 	// Mock a VPC Endpoint if an ID is supplied
 	if len(input.VpcEndpointIds) > 0 {
 		return &ec2.DescribeVpcEndpointsOutput{
@@ -59,43 +59,43 @@ func (m *mockedEC2) DescribeVpcEndpoints(input *ec2.DescribeVpcEndpointsInput) (
 	return &ec2.DescribeVpcEndpointsOutput{}, nil
 }
 
-func (m *mockedEC2) CreateVpcEndpoint(input *ec2.CreateVpcEndpointInput) (*ec2.CreateVpcEndpointOutput, error) {
+func (m *MockedEC2) CreateVpcEndpoint(input *ec2.CreateVpcEndpointInput) (*ec2.CreateVpcEndpointOutput, error) {
 	return &ec2.CreateVpcEndpointOutput{
 		VpcEndpoint: &ec2.VpcEndpoint{
-			VpcEndpointId: aws.String(mockVpcEndpointId),
+			VpcEndpointId: aws.String(MockVpcEndpointId),
 		},
 	}, nil
 }
 
-func (m *mockedEC2) DeleteVpcEndpoints(input *ec2.DeleteVpcEndpointsInput) (*ec2.DeleteVpcEndpointsOutput, error) {
+func (m *MockedEC2) DeleteVpcEndpoints(input *ec2.DeleteVpcEndpointsInput) (*ec2.DeleteVpcEndpointsOutput, error) {
 	return &ec2.DeleteVpcEndpointsOutput{}, nil
 }
 
 func TestAWSClient_DescribeSingleVPCEndpointById(t *testing.T) {
 	client := &AWSClient{
-		EC2Client: &mockedEC2{},
+		EC2Client: &MockedEC2{},
 	}
 
-	resp, err := client.DescribeSingleVPCEndpointById(mockVpcEndpointId)
+	resp, err := client.DescribeSingleVPCEndpointById(MockVpcEndpointId)
 	assert.NoError(t, err)
-	assert.Equal(t, mockVpcEndpointId, *resp.VpcEndpoints[0].VpcEndpointId)
+	assert.Equal(t, MockVpcEndpointId, *resp.VpcEndpoints[0].VpcEndpointId)
 }
 
 func TestAWSClient_FilterVPCEndpointByDefaultTags(t *testing.T) {
 	client := &AWSClient{
-		EC2Client: &mockedEC2{},
+		EC2Client: &MockedEC2{},
 	}
 
-	_, err := client.FilterVPCEndpointByDefaultTags(mockClusterTag)
+	_, err := client.FilterVPCEndpointByDefaultTags(MockClusterTag)
 	assert.NoError(t, err)
 }
 
 func TestCreateDeleteVPCEndpoint(t *testing.T) {
 	client := &AWSClient{
-		EC2Client: &mockedEC2{},
+		EC2Client: &MockedEC2{},
 	}
 
-	resp, err := client.CreateDefaultInterfaceVPCEndpoint("name", mockVpcId, mockVpcEndpointServiceName, mockClusterTag)
+	resp, err := client.CreateDefaultInterfaceVPCEndpoint("name", MockVpcId, MockVpcEndpointServiceName, MockClusterTag)
 	assert.NoError(t, err)
 
 	_, err = client.DeleteVPCEndpoint(*resp.VpcEndpoint.VpcEndpointId)

--- a/pkg/aws_client/vpc_endpoint_test.go
+++ b/pkg/aws_client/vpc_endpoint_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package aws_client
 
 import (
+	"github.com/openshift/aws-vpce-operator/pkg/testutil"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -24,45 +25,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (m *MockedEC2) DescribeVpcEndpoints(input *ec2.DescribeVpcEndpointsInput) (*ec2.DescribeVpcEndpointsOutput, error) {
-	// Mock a VPC Endpoint if an ID is supplied
-	if len(input.VpcEndpointIds) > 0 {
-		return &ec2.DescribeVpcEndpointsOutput{
-			VpcEndpoints: []*ec2.VpcEndpoint{
-				{
-					VpcEndpointId: input.VpcEndpointIds[0],
-				},
-			},
-		}, nil
-	}
-
-	// Mock a VPC Endpoint with a specified tag-key
-	if len(input.Filters) > 0 {
-		for _, filter := range input.Filters {
-			if *filter.Name == "tag-key" {
-				return &ec2.DescribeVpcEndpointsOutput{
-					VpcEndpoints: []*ec2.VpcEndpoint{
-						{
-							Tags: []*ec2.Tag{
-								{
-									Key:   filter.Values[0],
-									Value: nil,
-								},
-							},
-						},
-					},
-				}, nil
-			}
-		}
-	}
-
-	return &ec2.DescribeVpcEndpointsOutput{}, nil
-}
-
 func (m *MockedEC2) CreateVpcEndpoint(input *ec2.CreateVpcEndpointInput) (*ec2.CreateVpcEndpointOutput, error) {
 	return &ec2.CreateVpcEndpointOutput{
 		VpcEndpoint: &ec2.VpcEndpoint{
-			VpcEndpointId: aws.String(MockVpcEndpointId),
+			VpcEndpointId: aws.String(testutil.MockVpcEndpointId),
 		},
 	}, nil
 }
@@ -76,9 +42,9 @@ func TestAWSClient_DescribeSingleVPCEndpointById(t *testing.T) {
 		EC2Client: &MockedEC2{},
 	}
 
-	resp, err := client.DescribeSingleVPCEndpointById(MockVpcEndpointId)
+	resp, err := client.DescribeSingleVPCEndpointById(testutil.MockVpcEndpointId)
 	assert.NoError(t, err)
-	assert.Equal(t, MockVpcEndpointId, *resp.VpcEndpoints[0].VpcEndpointId)
+	assert.Equal(t, testutil.MockVpcEndpointId, *resp.VpcEndpoints[0].VpcEndpointId)
 }
 
 func TestAWSClient_FilterVPCEndpointByDefaultTags(t *testing.T) {

--- a/pkg/dnses/main_test.go
+++ b/pkg/dnses/main_test.go
@@ -60,7 +60,7 @@ func TestGetPrivateHostedZoneDomainName(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		mock := testutil.NewMock(t, test.dns)
+		mock := testutil.NewTestMock(t, test.dns)
 		actual, err := GetPrivateHostedZoneDomainName(context.TODO(), mock.Client)
 		if test.expectErr {
 			assert.NotNil(t, err)

--- a/pkg/infrastructures/main_test.go
+++ b/pkg/infrastructures/main_test.go
@@ -71,7 +71,7 @@ func TestGetInfrastructureName(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		mock := testutil.NewMock(t, test.infra)
+		mock := testutil.NewTestMock(t, test.infra)
 		actual, err := GetInfrastructureName(context.TODO(), mock.Client)
 		if test.expectErr {
 			assert.NotNil(t, err)
@@ -121,7 +121,7 @@ func TestGetAWSRegion(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		mock := testutil.NewMock(t, test.infra)
+		mock := testutil.NewTestMock(t, test.infra)
 		actual, err := GetAWSRegion(context.TODO(), mock.Client)
 		if test.expectErr {
 			assert.NotNil(t, err)

--- a/pkg/testutil/mock.go
+++ b/pkg/testutil/mock.go
@@ -26,11 +26,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-type Mock struct {
+type MockKubeClient struct {
 	Client client.Client
 }
 
-func NewMock(t *testing.T, objs ...client.Object) *Mock {
+func NewMock(t *testing.T, objs ...client.Object) *MockKubeClient {
 	s := runtime.NewScheme()
 	if err := configv1.Install(s); err != nil {
 		t.Fatal(err)
@@ -40,7 +40,7 @@ func NewMock(t *testing.T, objs ...client.Object) *Mock {
 		t.Fatal(err)
 	}
 
-	return &Mock{
+	return &MockKubeClient{
 		Client: fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).Build(),
 	}
 }


### PR DESCRIPTION
Needed to refactor the mocks built for unit testing the `aws_client` package so that they could be used when testing the controller.