### PR TITLE
OSD-11245 Unexporting ec2Client/route53Client

### DIFF
--- a/controllers/vpcendpoint/helpers.go
+++ b/controllers/vpcendpoint/helpers.go
@@ -83,7 +83,7 @@ func (r *VpcEndpointReconciler) parseClusterInfo(ctx context.Context, refreshAWS
 		if err != nil {
 			return err
 		}
-		r.awsClient = aws_client.New(sess)
+		r.awsClient = aws_client.NewAwsClient(sess)
 	}
 
 	infraName, err := infrastructures.GetInfrastructureName(ctx, r.Client)

--- a/controllers/vpcendpoint/helpers_test.go
+++ b/controllers/vpcendpoint/helpers_test.go
@@ -55,12 +55,10 @@ func TestParseClusterInfo(t *testing.T) {
 	}
 
 	r := &VpcEndpointReconciler{
-		Client: mock.Client,
-		log:    testr.New(t),
-		Scheme: mock.Client.Scheme(),
-		awsClient: &aws_client.AWSClient{
-			EC2Client: aws_client.NewMockedEC2WithSubnets(),
-		},
+		Client:      mock.Client,
+		log:         testr.New(t),
+		Scheme:      mock.Client.Scheme(),
+		awsClient:   aws_client.NewMockedAwsClientWithSubnets(),
 		clusterInfo: nil,
 	}
 
@@ -93,13 +91,10 @@ func TestDefaultResourceRecord(t *testing.T) {
 	}
 
 	r := &VpcEndpointReconciler{
-		Client: mock.Client,
-		log:    testr.New(t),
-		Scheme: mock.Client.Scheme(),
-		awsClient: &aws_client.AWSClient{
-			EC2Client:     aws_client.NewMockedEC2WithSubnets(),
-			Route53Client: aws_client.MockedRoute53{},
-		},
+		Client:      mock.Client,
+		log:         testr.New(t),
+		Scheme:      mock.Client.Scheme(),
+		awsClient:   aws_client.NewAwsClientWithServiceClients(aws_client.NewMockedEC2WithSubnets(), aws_client.MockedRoute53{}),
 		clusterInfo: nil,
 	}
 

--- a/controllers/vpcendpoint/validation.go
+++ b/controllers/vpcendpoint/validation.go
@@ -161,7 +161,7 @@ func (r *VpcEndpointReconciler) validateSecurityGroup(ctx context.Context, resou
 	// Fix tags if any are missing
 	if !TagsContains(sg.Tags, defaultTags) {
 		r.log.V(1).Info("Adding missing security group tags")
-		_, err := r.awsClient.EC2Client.CreateTags(&ec2.CreateTagsInput{
+		_, err := r.awsClient.CreateTags(&ec2.CreateTagsInput{
 			Resources: []*string{sg.GroupId},
 			Tags: []*ec2.Tag{
 				{
@@ -180,15 +180,7 @@ func (r *VpcEndpointReconciler) validateSecurityGroup(ctx context.Context, resou
 		}
 	}
 
-	// TODO: Break out DescribeSecurityGroupRules into a separate function
-	rulesResp, err := r.awsClient.EC2Client.DescribeSecurityGroupRules(&ec2.DescribeSecurityGroupRulesInput{
-		Filters: []*ec2.Filter{
-			{
-				Name:   aws.String("group-id"),
-				Values: []*string{sg.GroupId},
-			},
-		},
-	})
+	rulesResp, err := r.awsClient.DescribeSecurityGroupRules(*sg.GroupId)
 	if err != nil {
 		return err
 	}
@@ -410,7 +402,7 @@ func (r *VpcEndpointReconciler) validateVPCEndpoint(ctx context.Context, resourc
 	// DuplicateSubnetsInSameZone: Found another VPC endpoint subnet in the availability zone of <existing subnet>
 	if len(subnetsToRemove) > 0 {
 		r.log.V(1).Info("Removing subnet(s) from VPC Endpoint", "subnetsToRemove", subnetsToRemove)
-		if _, err := r.awsClient.EC2Client.ModifyVpcEndpoint(&ec2.ModifyVpcEndpointInput{
+		if _, err := r.awsClient.ModifyVpcEndpoint(&ec2.ModifyVpcEndpointInput{
 			RemoveSubnetIds: subnetsToRemove,
 			VpcEndpointId:   vpce.VpcEndpointId,
 		}); err != nil {
@@ -420,7 +412,7 @@ func (r *VpcEndpointReconciler) validateVPCEndpoint(ctx context.Context, resourc
 
 	if len(subnetsToAdd) > 0 {
 		r.log.V(1).Info("Adding subnet(s) to VPC Endpoint", "subnetsToAdd", subnetsToAdd)
-		if _, err := r.awsClient.EC2Client.ModifyVpcEndpoint(&ec2.ModifyVpcEndpointInput{
+		if _, err := r.awsClient.ModifyVpcEndpoint(&ec2.ModifyVpcEndpointInput{
 			AddSubnetIds:  subnetsToAdd,
 			VpcEndpointId: vpce.VpcEndpointId,
 		}); err != nil {
@@ -440,7 +432,7 @@ func (r *VpcEndpointReconciler) validateVPCEndpoint(ctx context.Context, resourc
 
 	if len(sgToAdd) > 0 {
 		r.log.V(1).Info("Adding security group(s) to VPC Endpoint", "sgToAdd", sgToAdd)
-		if _, err := r.awsClient.EC2Client.ModifyVpcEndpoint(&ec2.ModifyVpcEndpointInput{
+		if _, err := r.awsClient.ModifyVpcEndpoint(&ec2.ModifyVpcEndpointInput{
 			AddSecurityGroupIds: sgToAdd,
 			VpcEndpointId:       vpce.VpcEndpointId,
 		}); err != nil {
@@ -450,7 +442,7 @@ func (r *VpcEndpointReconciler) validateVPCEndpoint(ctx context.Context, resourc
 
 	if len(sgToRemove) > 0 {
 		r.log.V(1).Info("Removing security group(s) from VPC Endpoint", "sgToRemove", sgToRemove)
-		if _, err := r.awsClient.EC2Client.ModifyVpcEndpoint(&ec2.ModifyVpcEndpointInput{
+		if _, err := r.awsClient.ModifyVpcEndpoint(&ec2.ModifyVpcEndpointInput{
 			RemoveSecurityGroupIds: sgToRemove,
 			VpcEndpointId:          vpce.VpcEndpointId,
 		}); err != nil {

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"flag"
+	"go.uber.org/zap/zapcore"
 	"os"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -62,7 +63,8 @@ func main() {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	opts := zap.Options{
-		Development: true,
+		Development: false,
+		TimeEncoder: zapcore.RFC3339TimeEncoder,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()

--- a/pkg/aws_client/client.go
+++ b/pkg/aws_client/client.go
@@ -25,13 +25,20 @@ import (
 )
 
 type AWSClient struct {
-	EC2Client     ec2iface.EC2API
-	Route53Client route53iface.Route53API
+	ec2Client     ec2iface.EC2API
+	route53Client route53iface.Route53API
 }
 
-func New(sess *session.Session) *AWSClient {
-	client := new(AWSClient)
-	client.EC2Client = ec2.New(sess)
-	client.Route53Client = route53.New(sess)
-	return client
+// NewAwsClient returns an AWSClient with the provided session
+func NewAwsClient(sess *session.Session) *AWSClient {
+	return NewAwsClientWithServiceClients(ec2.New(sess), route53.New(sess))
+}
+
+// NewAwsClientWithServiceClients returns an AWSClient with the provided EC2 and Route53 clients.
+// Typically, not used directly except for building a mock for testing.
+func NewAwsClientWithServiceClients(ec2 ec2iface.EC2API, r53 route53iface.Route53API) *AWSClient {
+	return &AWSClient{
+		ec2Client:     ec2,
+		route53Client: r53,
+	}
 }

--- a/pkg/aws_client/mock.go
+++ b/pkg/aws_client/mock.go
@@ -93,6 +93,14 @@ func NewMockedEC2WithSubnets() *MockedEC2 {
 	}
 }
 
+func NewMockedAwsClient() *AWSClient {
+	return NewAwsClientWithServiceClients(&MockedEC2{}, &MockedRoute53{})
+}
+
+func NewMockedAwsClientWithSubnets() *AWSClient {
+	return NewAwsClientWithServiceClients(NewMockedEC2WithSubnets(), &MockedRoute53{})
+}
+
 func (m *MockedEC2) DescribeSubnets(input *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
 	tagKeys := map[string]bool{}
 	for _, filter := range input.Filters {

--- a/pkg/aws_client/route53_hosted_zone.go
+++ b/pkg/aws_client/route53_hosted_zone.go
@@ -30,7 +30,7 @@ func (c *AWSClient) GetDefaultPrivateHostedZoneId(domainName string) (*route53.H
 	}
 
 	// TODO: Unlikely, but would be nice to handle pagination
-	resp, err := c.Route53Client.ListHostedZonesByName(input)
+	resp, err := c.route53Client.ListHostedZonesByName(input)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +49,7 @@ func (c *AWSClient) ListResourceRecordSets(hostedZoneId string) (*route53.ListRe
 	}
 
 	// TODO: Handle pagination
-	resp, err := c.Route53Client.ListResourceRecordSets(input)
+	resp, err := c.route53Client.ListResourceRecordSets(input)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +73,7 @@ func (c *AWSClient) UpsertResourceRecordSet(rrs *route53.ResourceRecordSet, host
 		HostedZoneId: aws.String(hostedZoneId),
 	}
 
-	return c.Route53Client.ChangeResourceRecordSets(input)
+	return c.route53Client.ChangeResourceRecordSets(input)
 }
 
 // DeleteResourceRecordSet deletes a specific record from a hosted zone
@@ -92,5 +92,5 @@ func (c *AWSClient) DeleteResourceRecordSet(rrs *route53.ResourceRecordSet, host
 		HostedZoneId: aws.String(hostedZoneId),
 	}
 
-	return c.Route53Client.ChangeResourceRecordSets(input)
+	return c.route53Client.ChangeResourceRecordSets(input)
 }

--- a/pkg/aws_client/route53_hosted_zone_test.go
+++ b/pkg/aws_client/route53_hosted_zone_test.go
@@ -59,9 +59,7 @@ func TestAWSClient_GetDefaultPrivateHostedZoneId(t *testing.T) {
 		},
 	}
 
-	client := &AWSClient{
-		Route53Client: &MockedRoute53{},
-	}
+	client := NewMockedAwsClient()
 
 	for _, test := range tests {
 		_, err := client.GetDefaultPrivateHostedZoneId(test.domainName)
@@ -74,18 +72,14 @@ func TestAWSClient_GetDefaultPrivateHostedZoneId(t *testing.T) {
 }
 
 func TestAWSClient_ListResourceRecordSets(t *testing.T) {
-	client := &AWSClient{
-		Route53Client: &MockedRoute53{},
-	}
+	client := NewMockedAwsClient()
 
 	_, err := client.ListResourceRecordSets(MockHostedZoneId)
 	assert.NoError(t, err)
 }
 
 func TestAWSClient_UpsertDeleteResourceRecordSet(t *testing.T) {
-	client := &AWSClient{
-		Route53Client: &MockedRoute53{},
-	}
+	client := NewMockedAwsClient()
 
 	_, err := client.UpsertResourceRecordSet(mockResourceRecordSet, MockHostedZoneId)
 	assert.NoError(t, err)

--- a/pkg/aws_client/security_group.go
+++ b/pkg/aws_client/security_group.go
@@ -33,7 +33,7 @@ func (c *AWSClient) FilterClusterNodeSecurityGroupsByDefaultTags(infraName strin
 		return nil, err
 	}
 
-	return c.EC2Client.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
+	return c.ec2Client.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
 		Filters: []*ec2.Filter{
 			{
 				Name:   aws.String("tag-key"),
@@ -59,7 +59,7 @@ func (c *AWSClient) FilterSecurityGroupByDefaultTags(infraName string) (*ec2.Des
 		return nil, err
 	}
 
-	return c.EC2Client.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
+	return c.ec2Client.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
 		Filters: []*ec2.Filter{
 			{
 				Name:   aws.String("tag-key"),
@@ -85,7 +85,7 @@ func (c *AWSClient) FilterSecurityGroupById(groupId string) (*ec2.DescribeSecuri
 			aws.String(groupId),
 		},
 	}
-	resp, err := c.EC2Client.DescribeSecurityGroups(input)
+	resp, err := c.ec2Client.DescribeSecurityGroups(input)
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok {
 			// Don't return an error if the security group with the specified ID doesn't exist
@@ -117,29 +117,7 @@ func (c *AWSClient) CreateSecurityGroup(name, vpcId, tagKey string) (*ec2.Create
 		},
 		VpcId: &vpcId,
 	}
-	return c.EC2Client.CreateSecurityGroup(input)
-}
-
-func (c *AWSClient) AuthorizeSecurityGroupRules(ingress *ec2.AuthorizeSecurityGroupIngressInput, egress *ec2.AuthorizeSecurityGroupEgressInput) ([]*ec2.SecurityGroupRule, error) {
-	var rules []*ec2.SecurityGroupRule
-
-	if len(ingress.IpPermissions) > 0 {
-		ingressResp, err := c.EC2Client.AuthorizeSecurityGroupIngress(ingress)
-		if err != nil {
-			return nil, err
-		}
-		rules = append(rules, ingressResp.SecurityGroupRules...)
-	}
-
-	if len(egress.IpPermissions) > 0 {
-		egressResp, err := c.EC2Client.AuthorizeSecurityGroupEgress(egress)
-		if err != nil {
-			return nil, err
-		}
-		rules = append(rules, egressResp.SecurityGroupRules...)
-	}
-
-	return rules, nil
+	return c.ec2Client.CreateSecurityGroup(input)
 }
 
 // DeleteSecurityGroup deletes a security group with the specified ID
@@ -147,5 +125,5 @@ func (c *AWSClient) DeleteSecurityGroup(groupId string) (*ec2.DeleteSecurityGrou
 	input := &ec2.DeleteSecurityGroupInput{
 		GroupId: aws.String(groupId),
 	}
-	return c.EC2Client.DeleteSecurityGroup(input)
+	return c.ec2Client.DeleteSecurityGroup(input)
 }

--- a/pkg/aws_client/security_group_rules.go
+++ b/pkg/aws_client/security_group_rules.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws_client
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+// DescribeSecurityGroupRules describes the security group rules attached to a specific security group id
+func (c *AWSClient) DescribeSecurityGroupRules(groupId string) (*ec2.DescribeSecurityGroupRulesOutput, error) {
+	return c.ec2Client.DescribeSecurityGroupRules(&ec2.DescribeSecurityGroupRulesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("group-id"),
+				Values: []*string{aws.String(groupId)},
+			},
+		},
+	})
+}
+
+// AuthorizeSecurityGroupRules authorizes provided ingress and egress rules for a security group,
+// returning the updated security group rules and any errors
+func (c *AWSClient) AuthorizeSecurityGroupRules(ingress *ec2.AuthorizeSecurityGroupIngressInput, egress *ec2.AuthorizeSecurityGroupEgressInput) ([]*ec2.SecurityGroupRule, error) {
+	var rules []*ec2.SecurityGroupRule
+
+	if len(ingress.IpPermissions) > 0 {
+		ingressResp, err := c.ec2Client.AuthorizeSecurityGroupIngress(ingress)
+		if err != nil {
+			return nil, err
+		}
+		rules = append(rules, ingressResp.SecurityGroupRules...)
+	}
+
+	if len(egress.IpPermissions) > 0 {
+		egressResp, err := c.ec2Client.AuthorizeSecurityGroupEgress(egress)
+		if err != nil {
+			return nil, err
+		}
+		rules = append(rules, egressResp.SecurityGroupRules...)
+	}
+
+	return rules, nil
+}

--- a/pkg/aws_client/security_group_rules_test.go
+++ b/pkg/aws_client/security_group_rules_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws_client
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/stretchr/testify/assert"
+)
+
+func (m *MockedEC2) DescribeSecurityGroupRules(input *ec2.DescribeSecurityGroupRulesInput) (*ec2.DescribeSecurityGroupRulesOutput, error) {
+	// TODO: This is a no-op
+	return &ec2.DescribeSecurityGroupRulesOutput{
+		SecurityGroupRules: []*ec2.SecurityGroupRule{},
+	}, nil
+}
+
+func (m *MockedEC2) AuthorizeSecurityGroupIngress(input *ec2.AuthorizeSecurityGroupIngressInput) (*ec2.AuthorizeSecurityGroupIngressOutput, error) {
+	rules := make([]*ec2.SecurityGroupRule, len(input.IpPermissions))
+	for i, permission := range input.IpPermissions {
+		rules[i] = &ec2.SecurityGroupRule{
+			FromPort:   permission.FromPort,
+			IpProtocol: permission.IpProtocol,
+			ToPort:     permission.ToPort,
+		}
+	}
+
+	return &ec2.AuthorizeSecurityGroupIngressOutput{
+		SecurityGroupRules: rules,
+	}, nil
+}
+
+func (m *MockedEC2) AuthorizeSecurityGroupEgress(input *ec2.AuthorizeSecurityGroupEgressInput) (*ec2.AuthorizeSecurityGroupEgressOutput, error) {
+	rules := make([]*ec2.SecurityGroupRule, len(input.IpPermissions))
+	for i, permission := range input.IpPermissions {
+		rules[i] = &ec2.SecurityGroupRule{
+			FromPort:   permission.FromPort,
+			IpProtocol: permission.IpProtocol,
+			ToPort:     permission.ToPort,
+		}
+	}
+
+	return &ec2.AuthorizeSecurityGroupEgressOutput{
+		SecurityGroupRules: rules,
+	}, nil
+}
+
+func TestAWSClient_DescribeSecurityGroupRules(t *testing.T) {
+	tests := []struct {
+		groupId   string
+		expectErr bool
+	}{
+		{
+			groupId:   MockSecurityGroupId,
+			expectErr: false,
+		},
+	}
+
+	client := NewMockedAwsClient()
+
+	for _, test := range tests {
+		_, err := client.DescribeSecurityGroupRules(test.groupId)
+		if test.expectErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+		}
+	}
+}
+
+func TestAWSClient_AuthorizeSecurityGroupRules(t *testing.T) {
+	tests := []struct {
+		ingress          *ec2.AuthorizeSecurityGroupIngressInput
+		egress           *ec2.AuthorizeSecurityGroupEgressInput
+		expectedNumRules int
+		expectErr        bool
+	}{
+		{
+			ingress: &ec2.AuthorizeSecurityGroupIngressInput{
+				GroupId: aws.String(MockSecurityGroupId),
+				IpPermissions: []*ec2.IpPermission{
+					{
+						FromPort:   aws.Int64(80),
+						IpProtocol: aws.String("tcp"),
+						ToPort:     aws.Int64(80),
+					},
+				},
+			},
+			egress: &ec2.AuthorizeSecurityGroupEgressInput{
+				GroupId: aws.String(MockSecurityGroupId),
+				IpPermissions: []*ec2.IpPermission{
+					{
+						FromPort:   aws.Int64(80),
+						IpProtocol: aws.String("tcp"),
+						ToPort:     aws.Int64(80),
+					},
+				},
+			},
+			expectedNumRules: 2,
+			expectErr:        false,
+		},
+	}
+
+	client := NewMockedAwsClient()
+
+	for _, test := range tests {
+		resp, err := client.AuthorizeSecurityGroupRules(test.ingress, test.egress)
+		if test.expectErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+			assert.Equal(t, test.expectedNumRules, len(resp))
+		}
+	}
+}

--- a/pkg/aws_client/subnet.go
+++ b/pkg/aws_client/subnet.go
@@ -79,5 +79,5 @@ func (c *AWSClient) DescribeSubnetsByTagKey(tagKey ...string) (*ec2.DescribeSubn
 		Filters: filters,
 	}
 
-	return c.EC2Client.DescribeSubnets(input)
+	return c.ec2Client.DescribeSubnets(input)
 }

--- a/pkg/aws_client/subnet_test.go
+++ b/pkg/aws_client/subnet_test.go
@@ -39,9 +39,7 @@ func TestAWSClient_DescribeSubnets(t *testing.T) {
 		},
 	}
 
-	client := &AWSClient{
-		EC2Client: NewMockedEC2WithSubnets(),
-	}
+	client := NewMockedAwsClientWithSubnets()
 
 	for _, test := range tests {
 		actualPrivate, err := client.DescribePrivateSubnets(test.clusterTag)

--- a/pkg/aws_client/tags.go
+++ b/pkg/aws_client/tags.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws_client
+
+import "github.com/aws/aws-sdk-go/service/ec2"
+
+// CreateTags creates tags in an idempotent fashion
+func (c *AWSClient) CreateTags(input *ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error) {
+	return c.ec2Client.CreateTags(input)
+}

--- a/pkg/aws_client/tags_test.go
+++ b/pkg/aws_client/tags_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws_client
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/stretchr/testify/assert"
+)
+
+func (m *MockedEC2) CreateTags(input *ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error) {
+	// TODO: this is a no-op
+	return &ec2.CreateTagsOutput{}, nil
+}
+
+func TestAWSClient_CreateTags(t *testing.T) {
+	tests := []struct {
+		input     *ec2.CreateTagsInput
+		expectErr bool
+	}{
+		{
+			input:     &ec2.CreateTagsInput{},
+			expectErr: false,
+		},
+	}
+
+	client := NewMockedAwsClient()
+
+	for _, test := range tests {
+		_, err := client.CreateTags(test.input)
+		if test.expectErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+		}
+	}
+}

--- a/pkg/aws_client/vpc_endpoint.go
+++ b/pkg/aws_client/vpc_endpoint.go
@@ -37,7 +37,7 @@ func (c *AWSClient) DescribeSingleVPCEndpointById(id string) (*ec2.DescribeVpcEn
 		},
 	}
 
-	resp, err := c.EC2Client.DescribeVpcEndpoints(input)
+	resp, err := c.ec2Client.DescribeVpcEndpoints(input)
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok {
 			// Don't return an error if the VPC endpoint with the specified ID doesn't exist
@@ -61,7 +61,7 @@ func (c *AWSClient) FilterVPCEndpointByDefaultTags(clusterTag string) (*ec2.Desc
 		return &ec2.DescribeVpcEndpointsOutput{}, nil
 	}
 
-	return c.EC2Client.DescribeVpcEndpoints(&ec2.DescribeVpcEndpointsInput{
+	return c.ec2Client.DescribeVpcEndpoints(&ec2.DescribeVpcEndpointsInput{
 		Filters: []*ec2.Filter{
 			{
 				Name:   aws.String("tag-key"),
@@ -98,7 +98,7 @@ func (c *AWSClient) CreateDefaultInterfaceVPCEndpoint(name, vpcId, serviceName, 
 		},
 	}
 
-	return c.EC2Client.CreateVpcEndpoint(input)
+	return c.ec2Client.CreateVpcEndpoint(input)
 }
 
 // DeleteVPCEndpoint deletes a VPC endpoint with the given id.
@@ -109,5 +109,10 @@ func (c *AWSClient) DeleteVPCEndpoint(id string) (*ec2.DeleteVpcEndpointsOutput,
 		},
 	}
 
-	return c.EC2Client.DeleteVpcEndpoints(input)
+	return c.ec2Client.DeleteVpcEndpoints(input)
+}
+
+// ModifyVpcEndpoint modifies a VPC endpoint
+func (c *AWSClient) ModifyVpcEndpoint(input *ec2.ModifyVpcEndpointInput) (*ec2.ModifyVpcEndpointOutput, error) {
+	return c.ec2Client.ModifyVpcEndpoint(input)
 }

--- a/pkg/aws_client/vpc_endpoint_test.go
+++ b/pkg/aws_client/vpc_endpoint_test.go
@@ -34,13 +34,17 @@ func (m *MockedEC2) CreateVpcEndpoint(input *ec2.CreateVpcEndpointInput) (*ec2.C
 }
 
 func (m *MockedEC2) DeleteVpcEndpoints(input *ec2.DeleteVpcEndpointsInput) (*ec2.DeleteVpcEndpointsOutput, error) {
+	// TODO: This is a no-op
 	return &ec2.DeleteVpcEndpointsOutput{}, nil
 }
 
+func (m *MockedEC2) ModifyVpcEndpoint(input *ec2.ModifyVpcEndpointInput) (*ec2.ModifyVpcEndpointOutput, error) {
+	// TODO: This is a no-op
+	return &ec2.ModifyVpcEndpointOutput{}, nil
+}
+
 func TestAWSClient_DescribeSingleVPCEndpointById(t *testing.T) {
-	client := &AWSClient{
-		EC2Client: &MockedEC2{},
-	}
+	client := NewMockedAwsClient()
 
 	resp, err := client.DescribeSingleVPCEndpointById(testutil.MockVpcEndpointId)
 	assert.NoError(t, err)
@@ -48,22 +52,41 @@ func TestAWSClient_DescribeSingleVPCEndpointById(t *testing.T) {
 }
 
 func TestAWSClient_FilterVPCEndpointByDefaultTags(t *testing.T) {
-	client := &AWSClient{
-		EC2Client: &MockedEC2{},
-	}
+	client := NewMockedAwsClient()
 
 	_, err := client.FilterVPCEndpointByDefaultTags(MockClusterTag)
 	assert.NoError(t, err)
 }
 
 func TestCreateDeleteVPCEndpoint(t *testing.T) {
-	client := &AWSClient{
-		EC2Client: &MockedEC2{},
-	}
+	client := NewMockedAwsClient()
 
 	resp, err := client.CreateDefaultInterfaceVPCEndpoint("name", MockVpcId, MockVpcEndpointServiceName, MockClusterTag)
 	assert.NoError(t, err)
 
 	_, err = client.DeleteVPCEndpoint(*resp.VpcEndpoint.VpcEndpointId)
 	assert.NoError(t, err)
+}
+
+func TestAWSClient_ModifyVPCEndpoint(t *testing.T) {
+	tests := []struct {
+		input     *ec2.ModifyVpcEndpointInput
+		expectErr bool
+	}{
+		{
+			input:     &ec2.ModifyVpcEndpointInput{},
+			expectErr: false,
+		},
+	}
+
+	client := NewMockedAwsClient()
+
+	for _, test := range tests {
+		_, err := client.ModifyVpcEndpoint(test.input)
+		if test.expectErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+		}
+	}
 }


### PR DESCRIPTION
The meat of this change is not exporting ec2Client/route53Client (making them lowercase). This will help future developers as they'll be unable to access ec2Client/route53Client directly so that they need to implement functions in `pkg/awsclient` --> know that this operator will need new AWS permissions. Coming out of this, `CreateTags`,  `DescribeSecurityGroupRules`, and `ModifyVpcEndpoiont` were stragglers that were using the exported ec2Client and thus pulled out and simple test cases were added.

```
type AWSClient struct {
	ec2Client     ec2iface.EC2API
	route53Client route53iface.Route53API
}
```