### PR TITLE
OSD-12362 Handle update/deletion of the ExternalName service

### DIFF
--- a/controllers/vpcendpoint/vpcendpoint_controller.go
+++ b/controllers/vpcendpoint/vpcendpoint_controller.go
@@ -62,8 +62,8 @@ type clusterInfo struct {
 //+kubebuilder:rbac:groups=avo.openshift.io,resources=vpcendpoints,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=avo.openshift.io,resources=vpcendpoints/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=avo.openshift.io,resources=vpcendpoints/finalizers,verbs=update
-//+kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures,verbs=get
-//+kubebuilder:rbac:groups=config.openshift.io,resources=dnses,verbs=get
+//+kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures,verbs=get,list
+//+kubebuilder:rbac:groups=config.openshift.io,resources=dnses,verbs=get,list
 //+kubebuilder:rbac:groups=v1,resources=services,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=v1,resources=services/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
@@ -136,7 +136,7 @@ func (r *VpcEndpointReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	// Ensure the ExternalName service is in the right state
-	if err := r.ensureExternalNameService(ctx, avo); err != nil {
+	if err := r.validateExternalNameService(ctx, avo); err != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ func main() {
 		Port:                   9443,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "80030346.example.com",
+		LeaderElectionID:       "80030346.openshift.io",
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
Fixing a couple bugs in the ExternalName service code:

* By writing an `OwnerReference` for the controller, the service will be deleted (verified in testing as well) when the corresponding VpcEndpoint CR is deleted. Also added some logic to update the ExternalName service in case it gets modified.

  ```go
	if err := controllerutil.SetControllerReference(resource, svc, r.Scheme); err != nil {
		return nil, err
	}
  ```
* Added logic to update/fix the ExternalName service's `.spec.ExternalName` if it gets modified
* The generated ExternalName was using an incorrect variable
  ```go
  // Something like com.amazonaws.us-gov-west-1.vpce.000000.cluster0000.i1.devshift.com
  ExternalName: fmt.Sprintf("%s.%s", resource.Spec.ServiceName, r.clusterInfo.domainName),
  // vs. splunk.cluster0000.i1.devshift.com
  ExternalName: fmt.Sprintf("%s.%s", resource.Spec.SubdomainName, r.clusterInfo.domainName),
  ```
* Cleaned up leftover TODO's that were already fixed