### PR TITLE
OSD-12245 Add AWS VPCE status and ID to `kubectl get` output

### DIFF
--- a/api/v1alpha1/vpcendpoint_types.go
+++ b/api/v1alpha1/vpcendpoint_types.go
@@ -49,7 +49,7 @@ type SecurityGroup struct {
 
 // VpcEndpointSpec defines the desired state of VpcEndpoint
 type VpcEndpointSpec struct {
-	//+kubebuilder:validation:MinLength=0
+	// +kubebuilder:validation:MinLength=0
 
 	// ServiceName is the name of the VPC Endpoint Service to connect to
 	ServiceName string `json:"serviceName"`
@@ -93,8 +93,11 @@ type ExternalNameServiceSpec struct {
 	Namespace string `json:"namespace"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.status`
+// +kubebuilder:printcolumn:name="ID",type=string,JSONPath=`.status.vpcEndpointId`
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // VpcEndpoint is the Schema for the vpcendpoints API
 type VpcEndpoint struct {

--- a/deploy/crds/avo.openshift.io_vpcendpoints.yaml
+++ b/deploy/crds/avo.openshift.io_vpcendpoints.yaml
@@ -15,7 +15,17 @@ spec:
     singular: vpcendpoint
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.status
+      name: Status
+      type: string
+    - jsonPath: .status.vpcEndpointId
+      name: ID
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: VpcEndpoint is the Schema for the vpcendpoints API


### PR DESCRIPTION
Old version:
```
❯ k get vpcendpoint -n demo
NAME   AGE
demo   17m
```

After this PR:
```
❯ k get vpcendpoint -n demo       
NAME   STATUS      ID                       AGE
demo   available   vpce-0174ce88096d7b646   47m
```