### PR TITLE
OSD-12245 Adding a VPCE pendingAcceptance metric

### DIFF
--- a/api/v1alpha1/vpcendpoint_types.go
+++ b/api/v1alpha1/vpcendpoint_types.go
@@ -74,6 +74,9 @@ const (
 
 // VpcEndpointStatus defines the observed state of VpcEndpoint
 type VpcEndpointStatus struct {
+	// Status of the VPC Endpoint
+	Status string `json:"status,omitempty"`
+
 	// The AWS ID of the managed security group
 	// +optional
 	SecurityGroupId string `json:"securityGroupId,omitempty"`

--- a/controllers/vpcendpoint/cleanup.go
+++ b/controllers/vpcendpoint/cleanup.go
@@ -93,3 +93,12 @@ func (r *VpcEndpointReconciler) deleteAWSResources(ctx context.Context, resource
 
 	return nil
 }
+
+// cleanupMetrics deletes metrics associated with a specific custom resource in a best-effort manner
+func (r *VpcEndpointReconciler) cleanupMetrics(ctx context.Context, resource *avov1alpha1.VpcEndpoint) error {
+	// DeleteLabelValues returns true if the metric is deleted, false otherwise, currently we don't really care
+	// either way, so just always return nil
+	vpcePendingAcceptance.DeleteLabelValues(resource.Name, resource.Namespace)
+
+	return nil
+}

--- a/controllers/vpcendpoint/metrics.go
+++ b/controllers/vpcendpoint/metrics.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vpcendpoint
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	vpcePendingAcceptance = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "aws_vpce_operator_vpce_pendingAcceptance",
+			Help: "Count of VPC Endpoints in a pendingAcceptance state, labeled by name and namespace",
+		},
+		[]string{
+			"name",
+			"namespace",
+		},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(vpcePendingAcceptance)
+}

--- a/controllers/vpcendpoint/validation.go
+++ b/controllers/vpcendpoint/validation.go
@@ -410,6 +410,7 @@ func (r *VpcEndpointReconciler) validateVPCEndpoint(ctx context.Context, resourc
 	}
 
 	resource.Status.VPCEndpointId = *vpce.VpcEndpointId
+	resource.Status.Status = *vpce.State
 
 	switch *vpce.State {
 	case "pendingAcceptance":

--- a/controllers/vpcendpoint/validation.go
+++ b/controllers/vpcendpoint/validation.go
@@ -413,6 +413,7 @@ func (r *VpcEndpointReconciler) validateVPCEndpoint(ctx context.Context, resourc
 
 	switch *vpce.State {
 	case "pendingAcceptance":
+		vpcePendingAcceptance.WithLabelValues(resource.Name, resource.Namespace).Set(1)
 		// Nothing we can do at the moment, the VPC Endpoint needs to be accepted
 		r.log.V(0).Info("Waiting for VPC Endpoint connection acceptance", "status", *vpce.State)
 		meta.SetStatusCondition(&resource.Status.Conditions, metav1.Condition{
@@ -433,12 +434,14 @@ func (r *VpcEndpointReconciler) validateVPCEndpoint(ctx context.Context, resourc
 
 		return nil
 	case "available":
+		vpcePendingAcceptance.WithLabelValues(resource.Name, resource.Namespace).Set(0)
 		r.log.V(0).Info("VPC Endpoint ready", "status", *vpce.State)
 	case "failed", "rejected", "deleted":
 		// No other known states, but just in case catch with a default
 		fallthrough
 	default:
 		// TODO: If rejected, we may want an option to recreate the VPC Endpoint and try again
+		vpcePendingAcceptance.WithLabelValues(resource.Name, resource.Namespace).Set(0)
 		r.log.V(0).Info("VPC Endpoint in a bad state", "status", *vpce.State)
 		meta.SetStatusCondition(&resource.Status.Conditions, metav1.Condition{
 			Type:   avov1alpha1.AWSVpcEndpointCondition,

--- a/controllers/vpcendpoint/vpcendpoint_controller.go
+++ b/controllers/vpcendpoint/vpcendpoint_controller.go
@@ -115,6 +115,12 @@ func (r *VpcEndpointReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 				return ctrl.Result{}, err
 			}
 
+			// Cleanup the metric
+			if err := r.cleanupMetrics(ctx, avo); err != nil {
+				// Shouldn't happen
+				return ctrl.Result{}, err
+			}
+
 			// remove our finalizer from the list and update it.
 			controllerutil.RemoveFinalizer(avo, avoFinalizer)
 			if err := r.Update(ctx, avo); err != nil {

--- a/deploy/35_metrics_service.yaml
+++ b/deploy/35_metrics_service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: aws-vpce-operator-metrics
+  namespace: openshift-aws-vpce-operator
+spec:
+  selector:
+    name: aws-vpce-operator
+  ports:
+    - name: http-metrics
+      port: 80
+      protocol: TCP
+      targetPort: 8080

--- a/deploy/35_servicemonitor.yaml
+++ b/deploy/35_servicemonitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    name: aws-vpce-operator
+  name: aws-vpce-operator-metrics
+  namespace: openshift-aws-vpce-operator
+spec:
+  endpoints:
+    - port: http-metrics
+  namespaceSelector:
+    any: false
+    matchNames:
+      - openshift-aws-vpce-operator
+  selector:
+    matchLabels:
+      name: aws-vpce-operator

--- a/deploy/crds/avo.openshift.io_vpcendpoints.yaml
+++ b/deploy/crds/avo.openshift.io_vpcendpoints.yaml
@@ -205,6 +205,9 @@ spec:
               securityGroupId:
                 description: The AWS ID of the managed security group
                 type: string
+              status:
+                description: Status of the VPC Endpoint
+                type: string
               vpcEndpointId:
                 description: The AWS ID of the managed VPC Endpoint
                 type: string


### PR DESCRIPTION
* Adding a metric named `aws_vpce_operator_vpce_pendingAcceptance` so that we can be alerted (for now) when this operator creates a VPCE that needs to be accepted by an SRE. Eventually this will be automated, but the metric can still be used.
* Adding back the `Status` field because it gets displayed via `kubectl/oc get`
