### PR TITLE
OSD-12245 bugfixes to allow metrics to exist

### DIFF
--- a/deploy/30_prom-k8s-rolebinding.yaml
+++ b/deploy/30_prom-k8s-rolebinding.yaml
@@ -4,6 +4,7 @@ metadata:
   name: prometheus-k8s
   namespace: openshift-aws-vpce-operator
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: prometheus-k8s
 subjects:

--- a/deploy/35_metrics_service.yaml
+++ b/deploy/35_metrics_service.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    name: aws-vpce-operator
   name: aws-vpce-operator-metrics
   namespace: openshift-aws-vpce-operator
 spec:


### PR DESCRIPTION
* The Prometheus RoleBinding was missing a required field: `.roleRef.apiGroup`
* The [ServiceMonitor](https://github.com/openshift/aws-vpce-operator/blob/main/deploy/35_servicemonitor.yaml#L15-L17) had a labelSelector, but the Service had no labels, whoops!