### PR TITLE
OSD-12248 Fix typo

### DIFF
--- a/deploy/20_operator.yaml
+++ b/deploy/20_operator.yaml
@@ -27,7 +27,7 @@ spec:
             - name: "AWS_ROLE_ARN"
               valueFrom:
                 secretKeyRef:
-                  name: aws-avo-creds
+                  name: avo-aws-creds
                   key: role_arn
                   optional: false
             - name: "AWS_WEB_IDENTITY_TOKEN_FILE"


### PR DESCRIPTION
The secret name is avo-aws-creds (https://issues.redhat.com/browse/SDA-6264) also spelled correctly on line 64/66