### PR TITLE
OSD-12540 Remove now extraneous namespace label

### DIFF
--- a/controllers/vpcendpoint/cleanup.go
+++ b/controllers/vpcendpoint/cleanup.go
@@ -104,7 +104,7 @@ func (r *VpcEndpointReconciler) cleanupMetrics(ctx context.Context, resource *av
 	if resource.Status.VPCEndpointId != "" {
 		// DeleteLabelValues returns true if the metric is deleted, false otherwise, currently we don't really care
 		// either way, so just always return nil
-		vpcePendingAcceptance.DeleteLabelValues(resource.Name, "openshift-aws-vpce-operator", resource.Status.VPCEndpointId)
+		vpcePendingAcceptance.DeleteLabelValues(resource.Name, resource.Status.VPCEndpointId)
 	}
 
 	// If .status.VPCEndpointId is empty, we can't delete the metric, but don't care

--- a/controllers/vpcendpoint/metrics.go
+++ b/controllers/vpcendpoint/metrics.go
@@ -29,7 +29,6 @@ var (
 		},
 		[]string{
 			"name",
-			"namespace",
 			"vpce_id",
 		},
 	)

--- a/controllers/vpcendpoint/validation.go
+++ b/controllers/vpcendpoint/validation.go
@@ -414,7 +414,7 @@ func (r *VpcEndpointReconciler) validateVPCEndpoint(ctx context.Context, resourc
 
 	switch *vpce.State {
 	case "pendingAcceptance":
-		vpcePendingAcceptance.WithLabelValues(resource.Name, "openshift-aws-vpce-operator", resource.Status.VPCEndpointId).Set(1)
+		vpcePendingAcceptance.WithLabelValues(resource.Name, resource.Status.VPCEndpointId).Set(1)
 		// Nothing we can do at the moment, the VPC Endpoint needs to be accepted
 		r.log.V(0).Info("Waiting for VPC Endpoint connection acceptance", "status", *vpce.State)
 		meta.SetStatusCondition(&resource.Status.Conditions, metav1.Condition{
@@ -435,14 +435,14 @@ func (r *VpcEndpointReconciler) validateVPCEndpoint(ctx context.Context, resourc
 
 		return nil
 	case "available":
-		vpcePendingAcceptance.WithLabelValues(resource.Name, "openshift-aws-vpce-operator", resource.Status.VPCEndpointId).Set(0)
+		vpcePendingAcceptance.WithLabelValues(resource.Name, resource.Status.VPCEndpointId).Set(0)
 		r.log.V(0).Info("VPC Endpoint ready", "status", *vpce.State)
 	case "failed", "rejected", "deleted":
 		// No other known states, but just in case catch with a default
 		fallthrough
 	default:
 		// TODO: If rejected, we may want an option to recreate the VPC Endpoint and try again
-		vpcePendingAcceptance.WithLabelValues(resource.Name, "openshift-aws-vpce-operator", resource.Status.VPCEndpointId).Set(0)
+		vpcePendingAcceptance.WithLabelValues(resource.Name, resource.Status.VPCEndpointId).Set(0)
 		r.log.V(0).Info("VPC Endpoint in a bad state", "status", *vpce.State)
 		meta.SetStatusCondition(&resource.Status.Conditions, metav1.Condition{
 			Type:   avov1alpha1.AWSVpcEndpointCondition,


### PR DESCRIPTION
Now that https://github.com/openshift/managed-cluster-config/pull/1233 is merged, we are free to remove the `namespace` label that is now extraneous since this CRD became cluster-scope. (Previously the `PrometheusRule` CRs in MCC modified by that PR depended on a `namespace` label to exist)