### PR TITLE
OSD-12577 controller was reconciling security groups to an incorrect set of tags

### DIFF
--- a/pkg/util/naming.go
+++ b/pkg/util/naming.go
@@ -28,6 +28,8 @@ const (
 	SecurityGroupDescription = "Managed by AWS VPCE Operator"
 )
 
+// GenerateAwsTags returns the tags that should be reconciled on every AWS resource
+// created by this operator
 func GenerateAwsTags(name, clusterTagKey string) ([]*ec2.Tag, error) {
 	if name == "" || clusterTagKey == "" {
 		return nil, fmt.Errorf("name and clusterTagKey must not be empty")
@@ -47,6 +49,22 @@ func GenerateAwsTags(name, clusterTagKey string) ([]*ec2.Tag, error) {
 			Value: aws.String(name),
 		},
 	}, nil
+}
+
+// GenerateAwsTagsAsMap converts the slice of tags returned by GenerateAwsTags into a map
+// for convenience
+func GenerateAwsTagsAsMap(name, clusterTagKey string) (map[string]string, error) {
+	tags, err := GenerateAwsTags(name, clusterTagKey)
+	if err != nil {
+		return nil, err
+	}
+
+	tagsMap := map[string]string{}
+	for _, tag := range tags {
+		tagsMap[aws.StringValue(tag.Key)] = aws.StringValue(tag.Value)
+	}
+
+	return tagsMap, nil
 }
 
 // GetClusterTagKey returns the tag assigned to all AWS resources for the given cluster

--- a/pkg/util/naming_test.go
+++ b/pkg/util/naming_test.go
@@ -52,6 +52,45 @@ func TestGenerateAwsTags(t *testing.T) {
 	}
 }
 
+func TestGenerateAwsTagsAsMap(t *testing.T) {
+	tests := []struct {
+		name          string
+		clusterTagKey string
+		expectErr     bool
+		expected      map[string]string
+	}{
+		{
+			name:          "",
+			clusterTagKey: "",
+			expectErr:     true,
+		},
+		{
+			name:          "cluster",
+			clusterTagKey: "kubernetes.io/cluster/infra",
+			expectErr:     false,
+			expected: map[string]string{
+				"Name":                        "cluster",
+				"kubernetes.io/cluster/infra": "owned",
+				OperatorTagKey:                OperatorTagValue,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		actual, err := GenerateAwsTagsAsMap(test.name, test.clusterTagKey)
+		if test.expectErr {
+			assert.NotNil(t, err)
+		} else {
+			assert.Nil(t, err)
+			for k, v := range test.expected {
+				actualValue, ok := actual[k]
+				assert.True(t, ok)
+				assert.Equal(t, v, actualValue)
+			}
+		}
+	}
+}
+
 func TestGetClusterTagKey(t *testing.T) {
 	tests := []struct {
 		infraName string


### PR DESCRIPTION
The security groups were being reconciled to have tags of:
```go
	Tags: []*ec2.Tag{
		{
			Key:   aws.String(clusterTagKey),
			Value: aws.String(""),
		},
		{
			Key:   aws.String(OperatorTagKey),
			Value: aws.String(OperatorTagValue),
		},
	},
```
instead of:
```go
	Tags: []*ec2.Tag{
		{
			Key:   aws.String(OperatorTagKey),
			Value: aws.String(OperatorTagValue),
		},
		{
			Key:   aws.String(clusterTagKey),
			Value: aws.String("owned"),
		},
		{
			Key:   aws.String("Name"),
			Value: aws.String(name),
		},
	},
```

By setting the value of `clusterTagKey` to "", hive was failing to reap the security group when the cluster got deleted, preventing a successful deletion. Validated this by creating/accepting a VPCE in stage, seeing that the correct tags are reconciled, deleting the cluster, and verifying that the cluster successfully deletes now.