### PR TITLE
OSD-12750 Allow AVO to run in non-STS clusters

### DIFF
--- a/controllers/vpcendpoint/metrics.go
+++ b/controllers/vpcendpoint/metrics.go
@@ -25,7 +25,7 @@ var (
 	vpcePendingAcceptance = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "aws_vpce_operator_vpce_pendingAcceptance",
-			Help: "Count of VPC Endpoints in a pendingAcceptance state, labeled by name and namespace",
+			Help: "Count of VPC Endpoints in a pendingAcceptance state, labeled by name and AWS ID",
 		},
 		[]string{
 			"name",

--- a/controllers/vpcendpoint/vpcendpoint_controller.go
+++ b/controllers/vpcendpoint/vpcendpoint_controller.go
@@ -18,6 +18,7 @@ package vpcendpoint
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -72,7 +73,7 @@ func (r *VpcEndpointReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	reqLogger, err := defaultAVOLogger()
 	if err != nil {
 		// Shouldn't happen, but if it does, we can't log
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("unable to log: %w", err)
 	}
 
 	r.log = reqLogger.WithValues("Request.Name", req.Name)

--- a/deploy/20_operator.yaml
+++ b/deploy/20_operator.yaml
@@ -24,12 +24,24 @@ spec:
           command:
             - aws-vpce-operator
           env:
+            - name: "AWS_SECRET_ACCESS_KEY"
+              valueFrom:
+                secretKeyRef:
+                  name: avo-aws-iam-user-creds
+                  key: aws_secret_access_key
+                  optional: true
+            - name: "AWS_ACCESS_KEY_ID"
+              valueFrom:
+                secretKeyRef:
+                  name: avo-aws-iam-user-creds
+                  key: aws_access_key_id
+                  optional: true
             - name: "AWS_ROLE_ARN"
               valueFrom:
                 secretKeyRef:
                   name: avo-aws-creds
                   key: role_arn
-                  optional: false
+                  optional: true
             - name: "AWS_WEB_IDENTITY_TOKEN_FILE"
               value: "/var/run/secrets/openshift/serviceaccount/token"
           imagePullPolicy: Always
@@ -64,4 +76,8 @@ spec:
         - name: avo-aws-creds
           secret:
             secretName: avo-aws-creds
-            optional: false
+            optional: true
+        - name: avo-aws-iam-user-creds
+          secret:
+            secretName: avo-aws-iam-user-creds
+            optional: true

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -48,11 +48,11 @@ objects:
     - apiVersion: cloudcredential.openshift.io/v1
       kind: CredentialsRequest
       metadata:
-        name: aws-vpce-operator-credentials-aws
+        name: avo-aws-iam-user-creds
         namespace: openshift-aws-vpce-operator
       spec:
         secretRef:
-          name: aws-vpce-operator-credentials-aws
+          name: avo-aws-iam-user-creds
           namespace: openshift-aws-vpce-operator
         providerSpec:
           apiVersion: cloudcredential.openshift.io/v1


### PR DESCRIPTION
By marking all secrets as optional, AVO should be able to run in STS/non-STS mode depending on the secret available