### PR TITLE
OSD-12750 Unblock deployment to non-STS clusters

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -35,7 +35,6 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
         api.openshift.com/fedramp: 'true'
-        api.openshift.com/sts: 'true'
         api.openshift.com/private-link: 'true'
     resourceApplyMode: Sync
     resources:


### PR DESCRIPTION
Now that it's expected to run on non-STS clusters, unblock the SelectorSyncSet to allow deployment to non-STS clusters