### PR TITLE
OSD-12750 Fix typos in CredentialsRequest CR

### DIFF
--- a/controllers/vpcendpoint/helpers.go
+++ b/controllers/vpcendpoint/helpers.go
@@ -45,6 +45,8 @@ import (
 func defaultAVOLogger() (logr.Logger, error) {
 	config := zap.NewProductionConfig()
 	config.EncoderConfig.EncodeTime = zapcore.TimeEncoderOfLayout(time.RFC3339)
+	// TODO: Make this configurable
+	// config.Level = zap.NewAtomicLevelAt(zapcore.DebugLevel)
 
 	zapBase, err := config.Build()
 	if err != nil {

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -61,27 +61,27 @@ objects:
             resource: '*'
             action:
             # Extract vpc-id by searching for subnets by tag-key
-            - ec2:DescribeSubnets,
+            - ec2:DescribeSubnets
             # Create and manage security group in specific VPC
-            - ec2:CreateSecurityGroup,
-            - ec2:DeleteSecurityGroup,
-            - ec2:DescribeSecurityGroups,
+            - ec2:CreateSecurityGroup
+            - ec2:DeleteSecurityGroup
+            - ec2:DescribeSecurityGroups
             # Create and manage security group rules
-            - ec2:AuthorizeSecurityGroupIngress,
-            - ec2:AuthorizeSecurityGroupEgress,
-            - ec2:DescribeSecurityGroupRules,
+            - ec2:AuthorizeSecurityGroupIngress
+            - ec2:AuthorizeSecurityGroupEgress
+            - ec2:DescribeSecurityGroupRules
             # Create and manage a VPC endpoint
-            - ec2:CreateVpcEndpoint,
-            - ec2:DeleteVpcEndpoints,
-            - ec2:DescribeVpcEndpoints,
-            - ec2:ModifyVpcEndpoint,
+            - ec2:CreateVpcEndpoint
+            - ec2:DeleteVpcEndpoints
+            - ec2:DescribeVpcEndpoints
+            - ec2:ModifyVpcEndpoint
             # Create and manage a Route53 Record
-            - route53:ChangeResourceRecordSets,
-            - route53:ListHostedZonesByName,
-            - route53:ListResourceRecordSets,
+            - route53:ChangeResourceRecordSets
+            - route53:ListHostedZonesByName
+            - route53:ListResourceRecordSets
             # Manage tags and filter based on tags
-            - ec2:CreateTags,
-            - ec2:DeleteTags,
+            - ec2:CreateTags
+            - ec2:DeleteTags
             - ec2:DescribeTags
     - kind: RoleBinding
       apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/aws_client/subnet.go
+++ b/pkg/aws_client/subnet.go
@@ -34,7 +34,7 @@ const (
 func (c *AWSClient) GetVPCId(tagKey string) (string, error) {
 	subnets, err := c.DescribePrivateSubnets(tagKey)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("unable to DescribeSubnets: %w", err)
 	}
 
 	if len(subnets.Subnets) == 0 {


### PR DESCRIPTION
This was creating a policy with actions like (extra trailing comma):
```json
            "Action": [
                "ec2:DescribeSubnets,",
                "ec2:CreateSecurityGroup,",
            ]
```

Giving more information on this error (it wasn't obvious what it was failing on) and leaving a TODO because there's currently no way to adjust log level on-the-fly in the current implementation:

```json
{"level":"error","ts":"2022-08-23T02:34:18Z","msg":"Reconciler error","controller":"vpcendpoint","controllerGroup":"avo.openshift.io","controllerKind":"VpcEndpoint","vpcEndpoint":{"name":"splunk"},"namespace":"","name":"splunk","reconcileID":"1a4eefc9-1299-437b-9cf7-61007c5c99ae","error":"UnauthorizedOperation: You are not authorized to perform this operation.\n\tstatus code: 403, request id: f3e82236-4f7d-45fa-b302-53fbfe894e42","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\tpkg/mod/sigs.k8s.io/controller-runtime@v0.12.1/pkg/internal/controller/controller.go:234"}
```