### PR TITLE
OSD-12962 Add unit tests for VPCE validation

### DIFF
--- a/controllers/vpcendpoint/cleanup.go
+++ b/controllers/vpcendpoint/cleanup.go
@@ -30,7 +30,7 @@ import (
 // deleteAWSResources cleans up AWS resources associated with a VPC Endpoint.
 func (r *VpcEndpointReconciler) deleteAWSResources(ctx context.Context, resource *avov1alpha1.VpcEndpoint) error {
 	if meta.IsStatusConditionTrue(resource.Status.Conditions, avov1alpha1.AWSRoute53RecordCondition) {
-		resourceRecord, err := r.defaultResourceRecord(resource)
+		resourceRecord, err := r.generateRoute53Record(resource)
 		if err != nil {
 			return err
 		}

--- a/controllers/vpcendpoint/helpers_test.go
+++ b/controllers/vpcendpoint/helpers_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/go-logr/logr/testr"
-	"github.com/openshift/aws-vpce-operator/api/v1alpha1"
+	avov1alpha1 "github.com/openshift/aws-vpce-operator/api/v1alpha1"
 	"github.com/openshift/aws-vpce-operator/pkg/aws_client"
 	"github.com/openshift/aws-vpce-operator/pkg/testutil"
 	"github.com/stretchr/testify/assert"
@@ -53,7 +53,7 @@ func TestDefaultAVORateLimiter(t *testing.T) {
 	}
 }
 
-func TestParseClusterInfo(t *testing.T) {
+func TestVpcEndpointReconciler_parseClusterInfo(t *testing.T) {
 	mock, err := testutil.NewDefaultMock()
 	if err != nil {
 		t.Fatal(err)
@@ -71,21 +71,193 @@ func TestParseClusterInfo(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestDefaultResourceRecord(t *testing.T) {
+func TestVpcEndpointReconciler_findOrCreateVpcEndpoint(t *testing.T) {
 	tests := []struct {
-		resource  *v1alpha1.VpcEndpoint
-		expectErr bool
+		name        string
+		resource    *avov1alpha1.VpcEndpoint
+		clusterInfo *clusterInfo
+		expectErr   bool
 	}{
 		{
-			resource: &v1alpha1.VpcEndpoint{
-				Status: v1alpha1.VpcEndpointStatus{
+			name: "VPCEndpointID populated",
+			resource: &avov1alpha1.VpcEndpoint{
+				Status: avov1alpha1.VpcEndpointStatus{
 					VPCEndpointId: testutil.MockVpcEndpointId,
 				},
 			},
 			expectErr: false,
 		},
 		{
-			resource:  &v1alpha1.VpcEndpoint{},
+			name: "VPCEndpointID missing",
+			resource: &avov1alpha1.VpcEndpoint{
+				Status: avov1alpha1.VpcEndpointStatus{},
+			},
+			clusterInfo: &clusterInfo{
+				clusterTag: aws_client.MockClusterTag,
+				infraName:  testutil.MockInfrastructureName,
+				vpcId:      aws_client.MockVpcId,
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		r := &VpcEndpointReconciler{
+			log:         testr.New(t),
+			awsClient:   aws_client.NewMockedAwsClient(),
+			clusterInfo: test.clusterInfo,
+		}
+		t.Run(test.name, func(t *testing.T) {
+			_, err := r.findOrCreateVpcEndpoint(test.resource)
+			if test.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestVpcEndpointReconciler_diffVpcEndpointSubnets(t *testing.T) {
+	tests := []struct {
+		name                string
+		vpce                *ec2.VpcEndpoint
+		clusterTag          string
+		expectedNumToAdd    int
+		expectedNumToRemove int
+		expectErr           bool
+	}{
+		{
+			name:      "nil",
+			vpce:      nil,
+			expectErr: true,
+		},
+		{
+			name:       "exact match",
+			clusterTag: aws_client.MockClusterTag,
+			vpce: &ec2.VpcEndpoint{
+				SubnetIds: []*string{aws.String(aws_client.MockPrivateSubnetId)},
+			},
+			expectedNumToAdd:    0,
+			expectedNumToRemove: 0,
+			expectErr:           false,
+		},
+		{
+			name:                "subnet addition needed",
+			clusterTag:          aws_client.MockClusterTag,
+			vpce:                &ec2.VpcEndpoint{},
+			expectedNumToAdd:    1,
+			expectedNumToRemove: 0,
+			expectErr:           false,
+		},
+		{
+			name:       "subnet removal needed",
+			clusterTag: "some/random/tag",
+			vpce: &ec2.VpcEndpoint{
+				SubnetIds: []*string{aws.String(aws_client.MockPrivateSubnetId)},
+			},
+			expectedNumToAdd:    0,
+			expectedNumToRemove: 1,
+			expectErr:           false,
+		},
+	}
+
+	for _, test := range tests {
+		r := &VpcEndpointReconciler{
+			awsClient:   aws_client.NewMockedAwsClientWithSubnets(),
+			log:         testr.New(t),
+			clusterInfo: &clusterInfo{clusterTag: test.clusterTag},
+		}
+		t.Run(test.name, func(t *testing.T) {
+			actualToAdd, actualToRemove, err := r.diffVpcEndpointSubnets(test.vpce)
+			if test.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equalf(t, test.expectedNumToAdd, len(actualToAdd), "expected %d to add, got %d", test.expectedNumToAdd, len(actualToAdd))
+				assert.Equalf(t, test.expectedNumToRemove, len(actualToRemove), "expected %d to remove, got %d", test.expectedNumToRemove, len(actualToRemove))
+			}
+		})
+	}
+}
+
+func TestVpcEndpointReconciler_diffVpcEndpointSecurityGroups(t *testing.T) {
+	tests := []struct {
+		name                string
+		resource            *avov1alpha1.VpcEndpoint
+		vpce                *ec2.VpcEndpoint
+		expectedNumToAdd    int
+		expectedNumToRemove int
+	}{
+		{
+			name: "exact match",
+			resource: &avov1alpha1.VpcEndpoint{
+				Status: avov1alpha1.VpcEndpointStatus{
+					SecurityGroupId: aws_client.MockSecurityGroupId,
+				},
+			},
+			vpce: &ec2.VpcEndpoint{
+				Groups: []*ec2.SecurityGroupIdentifier{
+					{
+						GroupId: aws.String(aws_client.MockSecurityGroupId),
+					},
+				},
+			},
+			expectedNumToAdd:    0,
+			expectedNumToRemove: 0,
+		},
+		{
+			name: "need to add and remove",
+			resource: &avov1alpha1.VpcEndpoint{
+				Status: avov1alpha1.VpcEndpointStatus{
+					SecurityGroupId: aws_client.MockSecurityGroupId,
+				},
+			},
+			vpce: &ec2.VpcEndpoint{
+				Groups: []*ec2.SecurityGroupIdentifier{
+					{
+						GroupId: aws.String("sg-extra-to-remove"),
+					},
+				},
+			},
+			expectedNumToAdd:    1,
+			expectedNumToRemove: 1,
+		},
+	}
+
+	for _, test := range tests {
+		r := &VpcEndpointReconciler{
+			Client:      nil,
+			Scheme:      nil,
+			log:         testr.New(t),
+			awsClient:   nil,
+			clusterInfo: nil,
+		}
+		t.Run(test.name, func(t *testing.T) {
+			actualToAdd, actualToRemove, err := r.diffVpcEndpointSecurityGroups(test.vpce, test.resource)
+
+			assert.NoError(t, err)
+			assert.Equalf(t, test.expectedNumToAdd, len(actualToAdd), "expected to add %d, got %d", test.expectedNumToAdd, len(actualToAdd))
+			assert.Equalf(t, test.expectedNumToRemove, len(actualToRemove), "expected to remove %d, got %d", test.expectedNumToRemove, len(actualToRemove))
+		})
+	}
+}
+
+func TestVpcEndpointReconciler_generateRoute53Record(t *testing.T) {
+	tests := []struct {
+		resource  *avov1alpha1.VpcEndpoint
+		expectErr bool
+	}{
+		{
+			resource: &avov1alpha1.VpcEndpoint{
+				Status: avov1alpha1.VpcEndpointStatus{
+					VPCEndpointId: testutil.MockVpcEndpointId,
+				},
+			},
+			expectErr: false,
+		},
+		{
+			resource:  &avov1alpha1.VpcEndpoint{},
 			expectErr: true,
 		},
 	}
@@ -104,7 +276,7 @@ func TestDefaultResourceRecord(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		_, err = r.defaultResourceRecord(test.resource)
+		_, err = r.generateRoute53Record(test.resource)
 		if test.expectErr {
 			assert.Error(t, err)
 		} else {
@@ -113,21 +285,21 @@ func TestDefaultResourceRecord(t *testing.T) {
 	}
 }
 
-func TestServiceForVpce(t *testing.T) {
+func TestVpcEndpointReconciler_generateExternalNameService(t *testing.T) {
 	var (
 		trueBool = true
 	)
 	tests := []struct {
-		resource   *v1alpha1.VpcEndpoint
+		resource   *avov1alpha1.VpcEndpoint
 		domainName string
 		expected   *corev1.Service
 		expectErr  bool
 	}{
 		{
-			resource: &v1alpha1.VpcEndpoint{
-				Spec: v1alpha1.VpcEndpointSpec{
+			resource: &avov1alpha1.VpcEndpoint{
+				Spec: avov1alpha1.VpcEndpointSpec{
 					SubdomainName: "demo",
-					ExternalNameService: v1alpha1.ExternalNameServiceSpec{
+					ExternalNameService: avov1alpha1.ExternalNameServiceSpec{
 						Name:      "demo",
 						Namespace: "demo-ns",
 					},
@@ -155,9 +327,9 @@ func TestServiceForVpce(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			resource: &v1alpha1.VpcEndpoint{
-				Spec: v1alpha1.VpcEndpointSpec{
-					ExternalNameService: v1alpha1.ExternalNameServiceSpec{
+			resource: &avov1alpha1.VpcEndpoint{
+				Spec: avov1alpha1.VpcEndpointSpec{
+					ExternalNameService: avov1alpha1.ExternalNameServiceSpec{
 						Name:      "demo",
 						Namespace: "demo-ns",
 					},
@@ -167,10 +339,10 @@ func TestServiceForVpce(t *testing.T) {
 			expectErr:  true,
 		},
 		{
-			resource: &v1alpha1.VpcEndpoint{
-				Spec: v1alpha1.VpcEndpointSpec{
+			resource: &avov1alpha1.VpcEndpoint{
+				Spec: avov1alpha1.VpcEndpointSpec{
 					SubdomainName: "demo",
-					ExternalNameService: v1alpha1.ExternalNameServiceSpec{
+					ExternalNameService: avov1alpha1.ExternalNameServiceSpec{
 						Name:      "demo",
 						Namespace: "demo-ns",
 					},
@@ -195,7 +367,7 @@ func TestServiceForVpce(t *testing.T) {
 			},
 		}
 
-		actual, err := r.expectedServiceForVpce(test.resource)
+		actual, err := r.generateExternalNameService(test.resource)
 		if test.expectErr {
 			assert.Error(t, err)
 		} else {

--- a/pkg/aws_client/mock.go
+++ b/pkg/aws_client/mock.go
@@ -176,6 +176,11 @@ func (m *MockedEC2) DescribeVpcEndpoints(input *ec2.DescribeVpcEndpointsInput) (
 	return &ec2.DescribeVpcEndpointsOutput{}, nil
 }
 
+func (m *MockedEC2) ModifyVpcEndpoint(input *ec2.ModifyVpcEndpointInput) (*ec2.ModifyVpcEndpointOutput, error) {
+	// TODO: This is a no-op
+	return &ec2.ModifyVpcEndpointOutput{}, nil
+}
+
 func (m *MockedRoute53) ListHostedZonesByName(input *route53.ListHostedZonesByNameInput) (*route53.ListHostedZonesByNameOutput, error) {
 	return &route53.ListHostedZonesByNameOutput{
 		DNSName:      input.DNSName,

--- a/pkg/aws_client/vpc_endpoint.go
+++ b/pkg/aws_client/vpc_endpoint.go
@@ -62,6 +62,7 @@ func (c *AWSClient) FilterVPCEndpointByDefaultTags(clusterTag string) (*ec2.Desc
 	}
 
 	return c.ec2Client.DescribeVpcEndpoints(&ec2.DescribeVpcEndpointsInput{
+		// TODO: This filter doesn't work if there are multiple VPCE CR's in the same cluster
 		Filters: []*ec2.Filter{
 			{
 				Name:   aws.String("tag-key"),

--- a/pkg/aws_client/vpc_endpoint_test.go
+++ b/pkg/aws_client/vpc_endpoint_test.go
@@ -39,11 +39,6 @@ func (m *MockedEC2) DeleteVpcEndpoints(input *ec2.DeleteVpcEndpointsInput) (*ec2
 	return &ec2.DeleteVpcEndpointsOutput{}, nil
 }
 
-func (m *MockedEC2) ModifyVpcEndpoint(input *ec2.ModifyVpcEndpointInput) (*ec2.ModifyVpcEndpointOutput, error) {
-	// TODO: This is a no-op
-	return &ec2.ModifyVpcEndpointOutput{}, nil
-}
-
 func TestAWSClient_DescribeSingleVPCEndpointById(t *testing.T) {
 	client := NewMockedAwsClient()
 


### PR DESCRIPTION
[validateVPCEndpoint](https://github.com/openshift/aws-vpce-operator/blob/049e1a9a0feecd1fc96857511c29deb533a2d5b5/controllers/vpcendpoint/validation.go#274) is a notoriously lengthy and involved function, trumped only by `validateSecurityGroup` which is next on the list.

This PR is a slight refactor to make the code unit-test-able by pulling out some code into helper functions from `validation.go` to `helpers.go`. Unit tests were then added to `helpers_test.go` for those pieces and then a happy path unit test was added for `validateVPCEndpoint`