### PR TITLE
OSD-12962 findOrCreateSecurityGroup unit test

### DIFF
--- a/controllers/vpcendpoint/validation_test.go
+++ b/controllers/vpcendpoint/validation_test.go
@@ -46,6 +46,9 @@ func TestVPCEndpointReconciler_validateVPCEndpoint(t *testing.T) {
 		{
 			name: "minimum viable",
 			resource: &avov1alpha1.VpcEndpoint{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "mock1",
+				},
 				Status: avov1alpha1.VpcEndpointStatus{
 					VPCEndpointId: testutil.MockVpcEndpointId,
 				},
@@ -55,7 +58,13 @@ func TestVPCEndpointReconciler_validateVPCEndpoint(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		client := testutil.NewTestMock(t).Client
+		if test.resource != nil {
+			client = testutil.NewTestMock(t, test.resource).Client
+		}
 		r := &VpcEndpointReconciler{
+			Client:    client,
+			Scheme:    client.Scheme(),
 			awsClient: aws_client.NewMockedAwsClientWithSubnets(),
 			log:       testr.New(t),
 			clusterInfo: &clusterInfo{

--- a/pkg/aws_client/security_group_test.go
+++ b/pkg/aws_client/security_group_test.go
@@ -24,41 +24,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (m *MockedEC2) DescribeSecurityGroups(input *ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
-	if len(input.GroupIds) > 0 {
-		securityGroups := make([]*ec2.SecurityGroup, len(input.GroupIds))
-		for i, groupId := range input.GroupIds {
-			securityGroups[i] = &ec2.SecurityGroup{
-				GroupId: groupId,
-			}
-		}
-		return &ec2.DescribeSecurityGroupsOutput{
-			SecurityGroups: securityGroups,
-		}, nil
-	}
-
-	if len(input.Filters) > 0 {
-		for _, filter := range input.Filters {
-			if *filter.Name == "tag-key" {
-				return &ec2.DescribeSecurityGroupsOutput{
-					SecurityGroups: []*ec2.SecurityGroup{
-						{
-							Tags: []*ec2.Tag{
-								{
-									Key:   filter.Values[0],
-									Value: nil,
-								},
-							},
-						},
-					},
-				}, nil
-			}
-		}
-	}
-
-	return &ec2.DescribeSecurityGroupsOutput{}, nil
-}
-
 func (m *MockedEC2) CreateSecurityGroup(input *ec2.CreateSecurityGroupInput) (*ec2.CreateSecurityGroupOutput, error) {
 	if len(input.TagSpecifications) > 0 {
 		return &ec2.CreateSecurityGroupOutput{


### PR DESCRIPTION
Pulled out `findOrCreateSecurityGroup` from `validateSecurityGroup` and standardized it with `findOrCreateVpcEndpoint`