### PR TITLE
OSD-12962 Finish breaking apart `validateSecurityGroup` to enable unit testing

### DIFF
--- a/controllers/vpcendpoint/validation.go
+++ b/controllers/vpcendpoint/validation.go
@@ -21,10 +21,8 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/route53"
 	avov1alpha1 "github.com/openshift/aws-vpce-operator/api/v1alpha1"
-	"github.com/openshift/aws-vpce-operator/pkg/util"
 
 	corev1 "k8s.io/api/core/v1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
@@ -67,154 +65,13 @@ func (r *VpcEndpointReconciler) validateSecurityGroup(ctx context.Context, resou
 		return err
 	}
 
-	sgName, err := util.GenerateSecurityGroupName(r.clusterInfo.infraName, resource.Name)
-	if err != nil {
+	if err := r.createMissingSecurityGroupTags(sg, resource); err != nil {
 		return err
 	}
 
-	defaultTagsMap, err := util.GenerateAwsTagsAsMap(sgName, r.clusterInfo.clusterTag)
+	ingressInput, egressInput, err := r.generateMissingSecurityGroupRules(sg, resource)
 	if err != nil {
 		return err
-	}
-
-	// Fix tags if any are missing
-	if !tagsContains(sg.Tags, defaultTagsMap) {
-		r.log.V(1).Info("Adding missing security group tags")
-		defaultTags, err := util.GenerateAwsTags(sgName, r.clusterInfo.clusterTag)
-		if err != nil {
-			return err
-		}
-		if _, err := r.awsClient.CreateTags(&ec2.CreateTagsInput{
-			Resources: []*string{sg.GroupId},
-			Tags:      defaultTags,
-		}); err != nil {
-			return err
-		}
-	}
-
-	rulesResp, err := r.awsClient.DescribeSecurityGroupRules(*sg.GroupId)
-	if err != nil {
-		return err
-	}
-
-	sourceSgResp, err := r.awsClient.FilterClusterNodeSecurityGroupsByDefaultTags(r.clusterInfo.infraName)
-	if err != nil {
-		return err
-	}
-
-	sourceSgIds := make([]*string, len(sourceSgResp.SecurityGroups))
-	for i := range sourceSgResp.SecurityGroups {
-		sourceSgIds[i] = sourceSgResp.SecurityGroups[i].GroupId
-	}
-
-	// Ensure ingress/egress rules
-	var (
-		ingressRules []*ec2.IpPermission
-		egressRules  []*ec2.IpPermission
-	)
-
-	for i := range resource.Spec.SecurityGroup.IngressRules {
-		for _, sourceSgId := range sourceSgIds {
-			create := true
-			for _, rule := range rulesResp.SecurityGroupRules {
-				// If we find a rule with the correct protocol, fromPort, and toPort, check the source security group
-				if *rule.IpProtocol == resource.Spec.SecurityGroup.IngressRules[i].Protocol &&
-					*rule.FromPort == resource.Spec.SecurityGroup.IngressRules[i].FromPort &&
-					*rule.ToPort == resource.Spec.SecurityGroup.IngressRules[i].ToPort &&
-					*rule.ReferencedGroupInfo.GroupId == *sourceSgId {
-					create = false
-					break
-				}
-			}
-
-			if create {
-				ingressRules = append(ingressRules, &ec2.IpPermission{
-					IpProtocol: aws.String(resource.Spec.SecurityGroup.IngressRules[i].Protocol),
-					FromPort:   aws.Int64(resource.Spec.SecurityGroup.IngressRules[i].FromPort),
-					ToPort:     aws.Int64(resource.Spec.SecurityGroup.IngressRules[i].ToPort),
-					UserIdGroupPairs: []*ec2.UserIdGroupPair{
-						{
-							GroupId: sourceSgId,
-						},
-					},
-				})
-			}
-		}
-	}
-
-	for i := range resource.Spec.SecurityGroup.EgressRules {
-		for _, sourceSgId := range sourceSgIds {
-			create := true
-			for _, rule := range rulesResp.SecurityGroupRules {
-				if *rule.IpProtocol == resource.Spec.SecurityGroup.EgressRules[i].Protocol &&
-					*rule.FromPort == resource.Spec.SecurityGroup.EgressRules[i].FromPort &&
-					*rule.ToPort == resource.Spec.SecurityGroup.EgressRules[i].ToPort &&
-					*rule.ReferencedGroupInfo.GroupId == *sourceSgId {
-					create = false
-					break
-				}
-			}
-
-			if create {
-				egressRules = append(egressRules, &ec2.IpPermission{
-					IpProtocol: aws.String(resource.Spec.SecurityGroup.EgressRules[i].Protocol),
-					FromPort:   aws.Int64(resource.Spec.SecurityGroup.EgressRules[i].FromPort),
-					ToPort:     aws.Int64(resource.Spec.SecurityGroup.EgressRules[i].ToPort),
-					UserIdGroupPairs: []*ec2.UserIdGroupPair{
-						{
-							GroupId: sourceSgId,
-						},
-					},
-				})
-			}
-		}
-	}
-
-	if len(ingressRules) > 0 {
-		r.log.V(1).Info("Need to create ingress rules", "ingressRules", ingressRules)
-	}
-	if len(egressRules) > 0 {
-		r.log.V(1).Info("Need to create egress rules", "egressRules", egressRules)
-	}
-
-	ingressInput := &ec2.AuthorizeSecurityGroupIngressInput{
-		GroupId:       sg.GroupId,
-		IpPermissions: ingressRules,
-		TagSpecifications: []*ec2.TagSpecification{
-			{
-				ResourceType: aws.String("security-group-rule"),
-				Tags: []*ec2.Tag{
-					{
-						Key:   aws.String(r.clusterInfo.clusterTag),
-						Value: aws.String(""),
-					},
-					{
-						Key:   aws.String(util.OperatorTagKey),
-						Value: aws.String(util.OperatorTagValue),
-					},
-				},
-			},
-		},
-	}
-
-	egressInput := &ec2.AuthorizeSecurityGroupEgressInput{
-		GroupId:       sg.GroupId,
-		IpPermissions: egressRules,
-		TagSpecifications: []*ec2.TagSpecification{
-			{
-				ResourceType: aws.String("security-group-rule"),
-				Tags: []*ec2.Tag{
-					{
-						Key:   aws.String(r.clusterInfo.clusterTag),
-						Value: aws.String(""),
-					},
-					{
-						Key:   aws.String(util.OperatorTagKey),
-						Value: aws.String(util.OperatorTagValue),
-					},
-				},
-			},
-		},
 	}
 
 	// Not idempotent

--- a/controllers/vpcendpoint/validation.go
+++ b/controllers/vpcendpoint/validation.go
@@ -53,7 +53,6 @@ func (r *VpcEndpointReconciler) validateAWSResources(
 
 // validateSecurityGroup checks a security group against what's expected, returning an error if there are differences.
 // Security groups can't be updated-in-place, so a new one will need to be created before deleting this existing one.
-// TODO: Split out a ReconcileSecurityGroupRule function?
 func (r *VpcEndpointReconciler) validateSecurityGroup(ctx context.Context, resource *avov1alpha1.VpcEndpoint) error {
 	if resource == nil {
 		// Should never happen

--- a/controllers/vpcendpoint/validation_test.go
+++ b/controllers/vpcendpoint/validation_test.go
@@ -32,6 +32,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+func TestVPCEndpointReconciler_validateSecurityGroup(t *testing.T) {}
+
 func TestVPCEndpointReconciler_validateVPCEndpoint(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/pkg/aws_client/mock.go
+++ b/pkg/aws_client/mock.go
@@ -172,6 +172,36 @@ func (m *MockedEC2) DescribeSecurityGroupRules(input *ec2.DescribeSecurityGroupR
 	}, nil
 }
 
+func (m *MockedEC2) AuthorizeSecurityGroupIngress(input *ec2.AuthorizeSecurityGroupIngressInput) (*ec2.AuthorizeSecurityGroupIngressOutput, error) {
+	rules := make([]*ec2.SecurityGroupRule, len(input.IpPermissions))
+	for i, permission := range input.IpPermissions {
+		rules[i] = &ec2.SecurityGroupRule{
+			FromPort:   permission.FromPort,
+			IpProtocol: permission.IpProtocol,
+			ToPort:     permission.ToPort,
+		}
+	}
+
+	return &ec2.AuthorizeSecurityGroupIngressOutput{
+		SecurityGroupRules: rules,
+	}, nil
+}
+
+func (m *MockedEC2) AuthorizeSecurityGroupEgress(input *ec2.AuthorizeSecurityGroupEgressInput) (*ec2.AuthorizeSecurityGroupEgressOutput, error) {
+	rules := make([]*ec2.SecurityGroupRule, len(input.IpPermissions))
+	for i, permission := range input.IpPermissions {
+		rules[i] = &ec2.SecurityGroupRule{
+			FromPort:   permission.FromPort,
+			IpProtocol: permission.IpProtocol,
+			ToPort:     permission.ToPort,
+		}
+	}
+
+	return &ec2.AuthorizeSecurityGroupEgressOutput{
+		SecurityGroupRules: rules,
+	}, nil
+}
+
 func (m *MockedEC2) CreateTags(input *ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error) {
 	// TODO: this is a no-op
 	return &ec2.CreateTagsOutput{}, nil

--- a/pkg/aws_client/mock.go
+++ b/pkg/aws_client/mock.go
@@ -165,6 +165,18 @@ func (m *MockedEC2) DescribeSecurityGroups(input *ec2.DescribeSecurityGroupsInpu
 	return &ec2.DescribeSecurityGroupsOutput{}, nil
 }
 
+func (m *MockedEC2) DescribeSecurityGroupRules(input *ec2.DescribeSecurityGroupRulesInput) (*ec2.DescribeSecurityGroupRulesOutput, error) {
+	// TODO: This is a no-op
+	return &ec2.DescribeSecurityGroupRulesOutput{
+		SecurityGroupRules: []*ec2.SecurityGroupRule{},
+	}, nil
+}
+
+func (m *MockedEC2) CreateTags(input *ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error) {
+	// TODO: this is a no-op
+	return &ec2.CreateTagsOutput{}, nil
+}
+
 func (m *MockedEC2) DescribeVpcEndpoints(input *ec2.DescribeVpcEndpointsInput) (*ec2.DescribeVpcEndpointsOutput, error) {
 	// Mock a VPC Endpoint if an ID is supplied
 	if len(input.VpcEndpointIds) > 0 {

--- a/pkg/aws_client/security_group_rules_test.go
+++ b/pkg/aws_client/security_group_rules_test.go
@@ -24,36 +24,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (m *MockedEC2) AuthorizeSecurityGroupIngress(input *ec2.AuthorizeSecurityGroupIngressInput) (*ec2.AuthorizeSecurityGroupIngressOutput, error) {
-	rules := make([]*ec2.SecurityGroupRule, len(input.IpPermissions))
-	for i, permission := range input.IpPermissions {
-		rules[i] = &ec2.SecurityGroupRule{
-			FromPort:   permission.FromPort,
-			IpProtocol: permission.IpProtocol,
-			ToPort:     permission.ToPort,
-		}
-	}
-
-	return &ec2.AuthorizeSecurityGroupIngressOutput{
-		SecurityGroupRules: rules,
-	}, nil
-}
-
-func (m *MockedEC2) AuthorizeSecurityGroupEgress(input *ec2.AuthorizeSecurityGroupEgressInput) (*ec2.AuthorizeSecurityGroupEgressOutput, error) {
-	rules := make([]*ec2.SecurityGroupRule, len(input.IpPermissions))
-	for i, permission := range input.IpPermissions {
-		rules[i] = &ec2.SecurityGroupRule{
-			FromPort:   permission.FromPort,
-			IpProtocol: permission.IpProtocol,
-			ToPort:     permission.ToPort,
-		}
-	}
-
-	return &ec2.AuthorizeSecurityGroupEgressOutput{
-		SecurityGroupRules: rules,
-	}, nil
-}
-
 func TestAWSClient_DescribeSecurityGroupRules(t *testing.T) {
 	tests := []struct {
 		groupId   string

--- a/pkg/aws_client/security_group_rules_test.go
+++ b/pkg/aws_client/security_group_rules_test.go
@@ -24,13 +24,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (m *MockedEC2) DescribeSecurityGroupRules(input *ec2.DescribeSecurityGroupRulesInput) (*ec2.DescribeSecurityGroupRulesOutput, error) {
-	// TODO: This is a no-op
-	return &ec2.DescribeSecurityGroupRulesOutput{
-		SecurityGroupRules: []*ec2.SecurityGroupRule{},
-	}, nil
-}
-
 func (m *MockedEC2) AuthorizeSecurityGroupIngress(input *ec2.AuthorizeSecurityGroupIngressInput) (*ec2.AuthorizeSecurityGroupIngressOutput, error) {
 	rules := make([]*ec2.SecurityGroupRule, len(input.IpPermissions))
 	for i, permission := range input.IpPermissions {

--- a/pkg/aws_client/tags_test.go
+++ b/pkg/aws_client/tags_test.go
@@ -23,11 +23,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (m *MockedEC2) CreateTags(input *ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error) {
-	// TODO: this is a no-op
-	return &ec2.CreateTagsOutput{}, nil
-}
-
 func TestAWSClient_CreateTags(t *testing.T) {
 	tests := []struct {
 		input     *ec2.CreateTagsInput


### PR DESCRIPTION
This leaves `controllers/vpcendpoint/cleanup.go` as pretty much the last bastion to unit test