### PR TITLE
OSD-12962 unit testing cleanup functionality

### DIFF
--- a/controllers/vpcendpoint/cleanup.go
+++ b/controllers/vpcendpoint/cleanup.go
@@ -27,8 +27,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// deleteAWSResources cleans up AWS resources associated with a VPC Endpoint.
-func (r *VpcEndpointReconciler) deleteAWSResources(ctx context.Context, resource *avov1alpha1.VpcEndpoint) error {
+// cleanupAwsResources cleans up AWS resources associated with a VPC Endpoint.
+func (r *VpcEndpointReconciler) cleanupAwsResources(ctx context.Context, resource *avov1alpha1.VpcEndpoint) error {
 	if meta.IsStatusConditionTrue(resource.Status.Conditions, avov1alpha1.AWSRoute53RecordCondition) {
 		resourceRecord, err := r.generateRoute53Record(resource)
 		if err != nil {

--- a/controllers/vpcendpoint/cleanup_test.go
+++ b/controllers/vpcendpoint/cleanup_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vpcendpoint
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	avov1alpha1 "github.com/openshift/aws-vpce-operator/api/v1alpha1"
+	"github.com/openshift/aws-vpce-operator/pkg/aws_client"
+	"github.com/openshift/aws-vpce-operator/pkg/testutil"
+	"github.com/stretchr/testify/assert"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestVpcEndpointReconciler_cleanupAwsResources(t *testing.T) {
+	tests := []struct {
+		name      string
+		resource  *avov1alpha1.VpcEndpoint
+		expectErr bool
+	}{
+		{
+			name: "all resources needing cleanup",
+			resource: &avov1alpha1.VpcEndpoint{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "mock1",
+				},
+				Status: avov1alpha1.VpcEndpointStatus{
+					SecurityGroupId: aws_client.MockSecurityGroupId,
+					VPCEndpointId:   testutil.MockVpcEndpointId,
+					Conditions: []metav1.Condition{
+						{
+							Type:   avov1alpha1.AWSRoute53RecordCondition,
+							Status: metav1.ConditionTrue,
+						},
+					},
+				},
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		client := testutil.NewTestMock(t).Client
+		if test.resource != nil {
+			client = testutil.NewTestMock(t, test.resource).Client
+		}
+		r := &VpcEndpointReconciler{
+			Client:      client,
+			Scheme:      client.Scheme(),
+			awsClient:   aws_client.NewMockedAwsClientWithSubnets(),
+			log:         testr.New(t),
+			clusterInfo: &clusterInfo{},
+		}
+
+		err := r.cleanupAwsResources(context.TODO(), test.resource)
+		if test.expectErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+		}
+	}
+}

--- a/controllers/vpcendpoint/vpcendpoint_controller.go
+++ b/controllers/vpcendpoint/vpcendpoint_controller.go
@@ -103,7 +103,7 @@ func (r *VpcEndpointReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		// The object is being deleted
 		if controllerutil.ContainsFinalizer(avo, avoFinalizer) {
 			// our finalizer is present, so lets handle any external dependency
-			if err := r.deleteAWSResources(ctx, avo); err != nil {
+			if err := r.cleanupAwsResources(ctx, avo); err != nil {
 				if awsErr, ok := err.(awserr.Error); ok {
 					// VPC Endpoints take a bit of time to delete, so if there's a dependency error,
 					// we'll requeue the item, so we can try again later.

--- a/pkg/aws_client/mock.go
+++ b/pkg/aws_client/mock.go
@@ -129,6 +129,10 @@ func (m *MockedEC2) DescribeSubnets(input *ec2.DescribeSubnetsInput) (*ec2.Descr
 	return &ec2.DescribeSubnetsOutput{}, nil
 }
 
+func (m *MockedEC2) DeleteSecurityGroup(input *ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error) {
+	return &ec2.DeleteSecurityGroupOutput{}, nil
+}
+
 func (m *MockedEC2) DescribeSecurityGroups(input *ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
 	if len(input.GroupIds) > 0 {
 		securityGroups := make([]*ec2.SecurityGroup, len(input.GroupIds))
@@ -205,6 +209,11 @@ func (m *MockedEC2) AuthorizeSecurityGroupEgress(input *ec2.AuthorizeSecurityGro
 func (m *MockedEC2) CreateTags(input *ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error) {
 	// TODO: this is a no-op
 	return &ec2.CreateTagsOutput{}, nil
+}
+
+func (m *MockedEC2) DeleteVpcEndpoints(input *ec2.DeleteVpcEndpointsInput) (*ec2.DeleteVpcEndpointsOutput, error) {
+	// TODO: This is a no-op
+	return &ec2.DeleteVpcEndpointsOutput{}, nil
 }
 
 func (m *MockedEC2) DescribeVpcEndpoints(input *ec2.DescribeVpcEndpointsInput) (*ec2.DescribeVpcEndpointsOutput, error) {

--- a/pkg/aws_client/security_group_test.go
+++ b/pkg/aws_client/security_group_test.go
@@ -37,10 +37,6 @@ func (m *MockedEC2) CreateSecurityGroup(input *ec2.CreateSecurityGroupInput) (*e
 	}, nil
 }
 
-func (m *MockedEC2) DeleteSecurityGroup(input *ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error) {
-	return &ec2.DeleteSecurityGroupOutput{}, nil
-}
-
 func TestAWSClient_FilterClusterNodeSecurityGroupsByDefaultTags(t *testing.T) {
 	tests := []struct {
 		tagKey    string

--- a/pkg/aws_client/vpc_endpoint_test.go
+++ b/pkg/aws_client/vpc_endpoint_test.go
@@ -34,11 +34,6 @@ func (m *MockedEC2) CreateVpcEndpoint(input *ec2.CreateVpcEndpointInput) (*ec2.C
 	}, nil
 }
 
-func (m *MockedEC2) DeleteVpcEndpoints(input *ec2.DeleteVpcEndpointsInput) (*ec2.DeleteVpcEndpointsOutput, error) {
-	// TODO: This is a no-op
-	return &ec2.DeleteVpcEndpointsOutput{}, nil
-}
-
 func TestAWSClient_DescribeSingleVPCEndpointById(t *testing.T) {
 	client := NewMockedAwsClient()
 


### PR DESCRIPTION
Covering the `cleanup.go` as the last little piece that wasn't under some unit test coverage.