### PR TITLE
OSD-12962 Run as nonroot and help schedule on infra nodes

### DIFF
--- a/deploy/20_operator.yaml
+++ b/deploy/20_operator.yaml
@@ -14,6 +14,16 @@ spec:
         name: aws-vpce-operator
     spec:
       serviceAccountName: aws-vpce-operator
+      securityContext:
+        runAsNonRoot: true
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/infra
+                    operator: Exists
+              weight: 1
       tolerations:
         - operator: Exists
           key: node-role.kubernetes.io/infra


### PR DESCRIPTION
Generally good defaults that other operators in commercial have, e.g. MNMO https://github.com/openshift/managed-node-metadata-operator/blob/main/deploy/20_operator.yaml#L17-L26. This operator had a toleration for infra nodes, but no affinity, so this will help push it to be scheduled on infra nodes.