### PR TITLE
update probes and add securityContext settings to address warnings

### DIFF
--- a/deploy/20_operator.yaml
+++ b/deploy/20_operator.yaml
@@ -61,17 +61,27 @@ spec:
             limits:
               memory: "1G"
           livenessProbe:
-            httpGet:
-              path: /healthz
-              port: 8081
+            exec:
+              command: 
+              - /bin/bash
+              - -c 
+              - '[[ (! -z "$AWS_SECRET_ACCESS_KEY" && ! -z "$AWS_ACCESS_KEY_ID") || (! -z "$AWS_ROLE_ARN" && ! -z "$AWS_WEB_IDENTITY_TOKEN_FILE") ]]'
             initialDelaySeconds: 15
             periodSeconds: 20
           readinessProbe:
-            httpGet:
-              path: /readyz
-              port: 8081
+            exec:
+              command: 
+              - /bin/bash
+              - -c 
+              - '[[ (! -z "$AWS_SECRET_ACCESS_KEY" && ! -z "$AWS_ACCESS_KEY_ID") || (! -z "$AWS_ROLE_ARN" && ! -z "$AWS_WEB_IDENTITY_TOKEN_FILE") ]]'
             initialDelaySeconds: 5
             periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop: ["ALL"]
           volumeMounts:
             - name: openshift-sa-token
               mountPath: "/var/run/secrets/openshift/serviceaccount"

--- a/main.go
+++ b/main.go
@@ -30,7 +30,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -100,15 +99,6 @@ func main() {
 	//	os.Exit(1)
 	//}
 	//+kubebuilder:scaffold:builder
-
-	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
-		setupLog.Error(err, "unable to set up health check")
-		os.Exit(1)
-	}
-	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
-		setupLog.Error(err, "unable to set up ready check")
-		os.Exit(1)
-	}
 
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {


### PR DESCRIPTION
Addresses [OSD-12964](https://issues.redhat.com/browse/OSD-12964)
- updates the readiness and liveness probes to check that the AWS auth secrets exist otherwise it cannot create a VPC Endpoint, this should fail the pod before it tries to reconcile a CR.
- since the type of creds required varies on STS or not, the check looks for both and passes as long as one of them is successful.
- Adds security context configuration that explicity sets what appears to be defaults. This is to address warnings I saw on deploying to a 4.11 cluster.

```shell
W0906 15:50:34.753365   64831 warnings.go:70] would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "aws-vpce-operator" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "aws-vpce-operator" must set securityContext.capabilities.drop=["ALL"]), seccompProfile (pod or container "aws-vpce-operator" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
deployment.apps/aws-vpce-operator created
```