### PR TITLE
OSD-13108 Convert VPCE to be a namespaced CRD

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -9,6 +9,7 @@ repo: github.com/openshift/aws-vpce-operator
 resources:
 - api:
     crdVersion: v1
+    namespaced: true
   controller: true
   domain: openshift.io
   group: avo

--- a/api/v1alpha1/vpcendpoint_types.go
+++ b/api/v1alpha1/vpcendpoint_types.go
@@ -92,11 +92,8 @@ type VpcEndpointStatus struct {
 }
 
 type ExternalNameServiceSpec struct {
-	// Name of the ExternalName service
+	// Name of the ExternalName service to create in the same namespace as the VPCE CR
 	Name string `json:"name"`
-
-	// Namespace of the ExternalName service
-	Namespace string `json:"namespace"`
 }
 
 // +kubebuilder:subresource:status

--- a/api/v1alpha1/vpcendpoint_types.go
+++ b/api/v1alpha1/vpcendpoint_types.go
@@ -101,7 +101,7 @@ type ExternalNameServiceSpec struct {
 
 // +kubebuilder:subresource:status
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName={vpce},scope="Cluster"
+// +kubebuilder:resource:shortName={vpce},scope="Namespaced"
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.status`
 // +kubebuilder:printcolumn:name="ID",type=string,JSONPath=`.status.vpcEndpointId`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`

--- a/controllers/vpcendpoint/cleanup.go
+++ b/controllers/vpcendpoint/cleanup.go
@@ -104,7 +104,7 @@ func (r *VpcEndpointReconciler) cleanupMetrics(ctx context.Context, resource *av
 	if resource.Status.VPCEndpointId != "" {
 		// DeleteLabelValues returns true if the metric is deleted, false otherwise, currently we don't really care
 		// either way, so just always return nil
-		vpcePendingAcceptance.DeleteLabelValues(resource.Name, resource.Status.VPCEndpointId)
+		vpcePendingAcceptance.DeleteLabelValues(resource.Name, resource.Namespace, resource.Status.VPCEndpointId)
 	}
 
 	// If .status.VPCEndpointId is empty, we can't delete the metric, but don't care

--- a/controllers/vpcendpoint/helpers.go
+++ b/controllers/vpcendpoint/helpers.go
@@ -529,7 +529,7 @@ func (r *VpcEndpointReconciler) generateExternalNameService(resource *avov1alpha
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      resource.Spec.ExternalNameService.Name,
-			Namespace: resource.Spec.ExternalNameService.Namespace,
+			Namespace: resource.Namespace,
 		},
 		Spec: corev1.ServiceSpec{
 			Type:         corev1.ServiceTypeExternalName,

--- a/controllers/vpcendpoint/helpers_test.go
+++ b/controllers/vpcendpoint/helpers_test.go
@@ -484,9 +484,8 @@ func TestVpcEndpointReconciler_generateRoute53Record(t *testing.T) {
 }
 
 func TestVpcEndpointReconciler_generateExternalNameService(t *testing.T) {
-	var (
-		trueBool = true
-	)
+	var trueBool = true
+
 	tests := []struct {
 		resource   *avov1alpha1.VpcEndpoint
 		domainName string
@@ -495,11 +494,14 @@ func TestVpcEndpointReconciler_generateExternalNameService(t *testing.T) {
 	}{
 		{
 			resource: &avov1alpha1.VpcEndpoint{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "demo-vpce",
+					Namespace: "demo-ns",
+				},
 				Spec: avov1alpha1.VpcEndpointSpec{
 					SubdomainName: "demo",
 					ExternalNameService: avov1alpha1.ExternalNameServiceSpec{
-						Name:      "demo",
-						Namespace: "demo-ns",
+						Name: "demo",
 					},
 				},
 			},
@@ -512,6 +514,7 @@ func TestVpcEndpointReconciler_generateExternalNameService(t *testing.T) {
 						{
 							APIVersion:         "avo.openshift.io/v1alpha1",
 							Kind:               "VpcEndpoint",
+							Name:               "demo-vpce",
 							Controller:         &trueBool,
 							BlockOwnerDeletion: &trueBool,
 						},
@@ -526,10 +529,13 @@ func TestVpcEndpointReconciler_generateExternalNameService(t *testing.T) {
 		},
 		{
 			resource: &avov1alpha1.VpcEndpoint{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "demo-vpce",
+					Namespace: "demo-ns",
+				},
 				Spec: avov1alpha1.VpcEndpointSpec{
 					ExternalNameService: avov1alpha1.ExternalNameServiceSpec{
-						Name:      "demo",
-						Namespace: "demo-ns",
+						Name: "demo",
 					},
 				},
 			},
@@ -538,11 +544,14 @@ func TestVpcEndpointReconciler_generateExternalNameService(t *testing.T) {
 		},
 		{
 			resource: &avov1alpha1.VpcEndpoint{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "demo-vpce",
+					Namespace: "demo-ns",
+				},
 				Spec: avov1alpha1.VpcEndpointSpec{
 					SubdomainName: "demo",
 					ExternalNameService: avov1alpha1.ExternalNameServiceSpec{
-						Name:      "demo",
-						Namespace: "demo-ns",
+						Name: "demo",
 					},
 				},
 			},

--- a/controllers/vpcendpoint/metrics.go
+++ b/controllers/vpcendpoint/metrics.go
@@ -29,6 +29,7 @@ var (
 		},
 		[]string{
 			"name",
+			"namespace",
 			"vpce_id",
 		},
 	)

--- a/controllers/vpcendpoint/validation_test.go
+++ b/controllers/vpcendpoint/validation_test.go
@@ -226,10 +226,13 @@ func TestVPcEndpointReconciler_validateExternalNameService(t *testing.T) {
 		{
 			name: "need to create",
 			resource: &avov1alpha1.VpcEndpoint{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mock-vpce",
+					Namespace: "mockns",
+				},
 				Spec: avov1alpha1.VpcEndpointSpec{
 					ExternalNameService: avov1alpha1.ExternalNameServiceSpec{
-						Name:      "mock",
-						Namespace: "mockns",
+						Name: "mock",
 					},
 					SubdomainName: "mocksubdomain",
 				},
@@ -241,10 +244,13 @@ func TestVPcEndpointReconciler_validateExternalNameService(t *testing.T) {
 		{
 			name: "need to modify",
 			resource: &avov1alpha1.VpcEndpoint{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mock-vpce",
+					Namespace: "mockns",
+				},
 				Spec: avov1alpha1.VpcEndpointSpec{
 					ExternalNameService: avov1alpha1.ExternalNameServiceSpec{
-						Name:      "mock",
-						Namespace: "mockns",
+						Name: "mock",
 					},
 					SubdomainName: "mocksubdomain",
 				},

--- a/controllers/vpcendpoint/vpcendpoint_controller.go
+++ b/controllers/vpcendpoint/vpcendpoint_controller.go
@@ -79,7 +79,7 @@ func (r *VpcEndpointReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, fmt.Errorf("unable to log: %w", err)
 	}
 
-	r.log = reqLogger.WithValues("Request.Name", req.Name)
+	r.log = reqLogger.WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name)
 
 	if err := r.parseClusterInfo(ctx, true); err != nil {
 		return ctrl.Result{}, err

--- a/deploy/crds/avo.openshift.io_vpcendpoints.yaml
+++ b/deploy/crds/avo.openshift.io_vpcendpoints.yaml
@@ -52,7 +52,8 @@ spec:
                   of the created Kubernetes ExternalName Service
                 properties:
                   name:
-                    description: Name of the ExternalName service
+                    description: Name of the ExternalName service to create in the
+                      same namespace as the VPCE CR
                     type: string
                 required:
                 - name

--- a/deploy/crds/avo.openshift.io_vpcendpoints.yaml
+++ b/deploy/crds/avo.openshift.io_vpcendpoints.yaml
@@ -15,7 +15,7 @@ spec:
     shortNames:
     - vpce
     singular: vpcendpoint
-  scope: Cluster
+  scope: Namespaced
   versions:
   - additionalPrinterColumns:
     - jsonPath: .status.status
@@ -54,12 +54,8 @@ spec:
                   name:
                     description: Name of the ExternalName service
                     type: string
-                  namespace:
-                    description: Namespace of the ExternalName service
-                    type: string
                 required:
                 - name
-                - namespace
                 type: object
               securityGroup:
                 description: SecurityGroup contains the configuration of the security


### PR DESCRIPTION
Essentially a revert of https://github.com/openshift/aws-vpce-operator/pull/36 to allow this operator to be more flexibly used in HyperShift.

Additionally, `.spec.externalNameService.namespace` has been removed as the expectation is now that the `ExternalName` service must be in the same namespace as the VPCE CR.
