### PR TITLE
strips scc settings as it breaks deployments in 4.10 and is not required

### DIFF
--- a/deploy/20_operator.yaml
+++ b/deploy/20_operator.yaml
@@ -78,6 +78,8 @@ spec:
               - '[[ (! -z "$AWS_SECRET_ACCESS_KEY" && ! -z "$AWS_ACCESS_KEY_ID") || (! -z "$AWS_ROLE_ARN" && ! -z "$AWS_WEB_IDENTITY_TOKEN_FILE") ]]'
             initialDelaySeconds: 5
             periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
           volumeMounts:
             - name: openshift-sa-token
               mountPath: "/var/run/secrets/openshift/serviceaccount"

--- a/deploy/20_operator.yaml
+++ b/deploy/20_operator.yaml
@@ -78,12 +78,6 @@ spec:
               - '[[ (! -z "$AWS_SECRET_ACCESS_KEY" && ! -z "$AWS_ACCESS_KEY_ID") || (! -z "$AWS_ROLE_ARN" && ! -z "$AWS_WEB_IDENTITY_TOKEN_FILE") ]]'
             initialDelaySeconds: 5
             periodSeconds: 10
-          securityContext:
-            allowPrivilegeEscalation: false
-            seccompProfile:
-              type: RuntimeDefault
-            capabilities:
-              drop: ["ALL"]
           volumeMounts:
             - name: openshift-sa-token
               mountPath: "/var/run/secrets/openshift/serviceaccount"


### PR DESCRIPTION
- scc settings in the deployment are not fully compatible with workloads in 4.10 clusters. As its not required or making any changes, stripping this out for now.