### PR TITLE
OSD-13445 update olm template for VPC acceptance config

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -15,6 +15,9 @@ parameters:
 - name: DISPLAY_NAME
   value: AWS VPCE Operator
   required: true
+- name: ENABLE_VPC_ACCEPTANCE  
+  value: false
+  required: true
 metadata:
   name: selectorsyncset-template
 objects:
@@ -149,3 +152,14 @@ objects:
         name: ${REPO_NAME}
         source: ${REPO_NAME}-registry
         sourceNamespace: openshift-${REPO_NAME}
+    - apiVersion: v1
+      data:
+        avo_config.yaml: |-
+          apiVersion: avo.openshift.io/v1alpha1
+          kind: AvoConfig
+          enableVpcEndpointController: true
+          enableVpcEndpointAcceptanceController: ${ENABLE_VPC_ACCEPTANCE}
+      kind: ConfigMap
+      metadata:
+        name: avo-config
+        namespace: openshift-aws-vpce-operator

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -51,11 +51,11 @@ objects:
       kind: CredentialsRequest
       metadata:
         name: avo-aws-iam-user-creds
-        namespace: openshift-aws-vpce-operator
+        namespace: openshift-${REPO_NAME}
       spec:
         secretRef:
           name: avo-aws-iam-user-creds
-          namespace: openshift-aws-vpce-operator
+          namespace: openshift-${REPO_NAME}
         providerSpec:
           apiVersion: cloudcredential.openshift.io/v1
           kind: AWSProviderSpec
@@ -94,15 +94,15 @@ objects:
       apiVersion: rbac.authorization.k8s.io/v1
       metadata:
         name: aws-vpce-operator
-        namespace: openshift-aws-vpce-operator
+        namespace: openshift-${REPO_NAME}
       subjects:
       - kind: ServiceAccount
         name: aws-vpce-operator
-        namespace: openshift-aws-vpce-operator
+        namespace: openshift-${REPO_NAME}
       roleRef:
         kind: Role
         name: aws-vpce-operator
-        namespace: openshift-aws-vpce-operator
+        namespace: openshift-${REPO_NAME}
         apiGroup: rbac.authorization.k8s.io
     - apiVersion: operators.coreos.com/v1alpha1
       kind: CatalogSource
@@ -162,4 +162,4 @@ objects:
       kind: ConfigMap
       metadata:
         name: avo-config
-        namespace: openshift-aws-vpce-operator
+        namespace: openshift-${REPO_NAME}


### PR DESCRIPTION
For [OSD-13345](https://issues.redhat.com/browse/OSD-13445)
- Adds the configmap needed to enable the VPC Acceptance controller in AVO
- Adds a bool to allow turning this setting on or off in App interface so changes can be tested on individual hives in non-prod first