### PR TITLE
updates new vpc acceptance var to a string value

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -16,7 +16,7 @@ parameters:
   value: AWS VPCE Operator
   required: true
 - name: ENABLE_VPC_ACCEPTANCE  
-  value: false
+  value: "false"
   required: true
 metadata:
   name: selectorsyncset-template


### PR DESCRIPTION
saasherder in app interface does not like bools, this updates the ENABLE_VPC_ACCEPTANCE var to be a string value, so that A-I can use strings as well. This matches similar method used in [AAO](https://github.com/openshift/aws-account-operator/blob/master/hack/olm-registry/olm-artifacts-template.yaml#L41) as well. The code does not need to be changed to use a string as AAO still uses a bool in the config as well