### PR TITLE
OSD-13445: adds AAO to scheme to allow for listing Accounts

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	configv1 "github.com/openshift/api/config/v1"
+	aaov1alpha1 "github.com/openshift/aws-account-operator/api/v1alpha1"
 	avov1alpha1 "github.com/openshift/aws-vpce-operator/api/v1alpha1"
 	"github.com/openshift/aws-vpce-operator/controllers/vpcendpoint"
 	"github.com/openshift/aws-vpce-operator/controllers/vpcendpointacceptance"
@@ -49,6 +50,9 @@ func init() {
 
 	// Add config.openshift.io/v1 for the infrastructures CR
 	utilruntime.Must(configv1.Install(scheme))
+
+	// Add aws.managed.openshift.io/v1alpha1 for the AccountList CR
+	utilruntime.Must(aaov1alpha1.AddToScheme(scheme))
 
 	utilruntime.Must(avov1alpha1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme


### PR DESCRIPTION
For [OSD-13445](https://issues.redhat.com//browse/OSD-13445)
- Adds AAO package to Scheme in order to access AAO CR's for vpce acceptance

Why:
When testing VpcEnpointAcceptance reconciliation, the controller throws errors saying `no kind is registered for the type v1alpha1.AccountList`. AVO is attempting to list the Account CR's available through AAO but does not know what that object is. Adding it to the scheme should make list Accounts available to the controller. 

[See Comment](https://issues.redhat.com/browse/OSD-13445?focusedCommentId=21134909&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-21134909) in Jira for more  details
