### PR TITLE
OSD-13445: updates clusterrole and README for acceptance object

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,28 @@ spec:
 * `.spec.externalNameService` defines the name and namespace the ExternalName service that will be created pointing to the Route53 record created above.
 * `.spec.securityGroup` defines security group ingress and egress rules that will be attached to the created VPC Endpoint
 
+## VpcEndpointAcceptance
+
+```yaml
+---
+apiVersion: avo.openshift.io/v1alpha1
+kind: VpcEndpointAcceptance
+metadata:
+  name: example-acceptance
+  namespace: example-namespace
+spec:
+  id: "vpce-svc-123456789"
+  assumeRoleArn: "arn:aws-us-gov:iam::123456789:role/exampleIAMrole"
+  region: "us-gov-west-1"
+  acceptanceCriteria:
+    awsAccountOperatorAccount:
+      namespace: aws-account-operator
+```
+
+* `.spec.id` is the Service ID of the VPC Endpoint Service to connect to
+* `.spec.assumeRoleArn` is the IAM role in the account of the Endpoint Service that grants permission to handle acceptance
+* `.spec.region` is the AWS region where the Endpoint Service resides
+
 # Development
 
 Looking to work on this? See [dev/README.md](./dev/README.md)

--- a/deploy/15_clusterrole.yaml
+++ b/deploy/15_clusterrole.yaml
@@ -15,10 +15,11 @@ rules:
   - apiGroups:
     - aws.managed.openshift.io
     resources:
-    - account
+    - accounts
     verbs:
     - get
     - list
+    - watch
   - apiGroups:
     - avo.openshift.io
     resources:

--- a/dev/vpce_acceptance_example.yml
+++ b/dev/vpce_acceptance_example.yml
@@ -1,0 +1,12 @@
+apiVersion: avo.openshift.io/v1alpha1
+kind: VpcEndpointAcceptance
+metadata:
+  name: splunk-acceptance
+  namespace: openshift-aws-vpce-operator
+spec:
+  id: "vpce-svc-06225ed6e3620e8e1"
+  assumeRoleArn: "arn:aws-us-gov:iam::486461443045:role/SplunkVpceAcceptance"
+  region: "us-gov-west-1"
+  acceptanceCriteria:
+    awsAccountOperatorAccount:
+      namespace: aws-account-operator


### PR DESCRIPTION
For [OSD-13445](https://issues.redhat.com//browse/OSD-13445),
- fixes the role used by the operator, it was missing the `watch` function, and also the object was incorrect, it needed to be `accounts` not `account` 
- adds example vpce acceptance object and info in the README for use

The role has been tested in integration and I am able to successfully auto-accept the vpce endpoint for splunk, just had to make the role change first. This is to finalize that.