### PR TITLE
OSD-13445: updates olm template for avo config on hive only

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -152,6 +152,24 @@ objects:
         name: ${REPO_NAME}
         source: ${REPO_NAME}-registry
         sourceNamespace: openshift-${REPO_NAME}
+# config for hives only to enable VpcEndpointAcceptance        
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    name: aws-vpce-operator-frhive-sss
+  spec:
+    clusterDeploymentSelector:
+      matchExpressions:
+        - key: api.openshift.com/fedramp
+          operator: In
+          values:
+            - "true"
+        - key: ext-managed.openshift.io/hive-shard
+          operator: In
+          values:
+            - "true"
+    resourceApplyMode: Sync
+    resources:                    
     - apiVersion: v1
       data:
         avo_config.yaml: |-


### PR DESCRIPTION
For [OSD-13445](https://issues.redhat.com/browse/OSD-13445)
- updates the olm template to use a separate SelectorSyncSet for the AVO configmap this way we can target fedramp hives exclusively and not deploy this config to non-hive clusters or any commercial clusters if being tested there until desired
- this config is required to enable the second controller for VPC Endpoint acceptance to be functional
- the actual AVO config is already validated as working, this is to prevent us from enabling the second controller on customer clusters as its not usable there
- validation of the feature/config working in jira card