### PR TITLE
updates olm template to remove avo config

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,14 @@ spec:
 * `.spec.assumeRoleArn` is the IAM role in the account of the Endpoint Service that grants permission to handle acceptance
 * `.spec.region` is the AWS region where the Endpoint Service resides
 
+# FedRAMP Cluster Deployments
+
+AVO is currently deployed to all FedRAMP clusters through App Interface using the template in this repo and OLM. To ensure clusters are automatically configured for Splunk log forwarding, a VPC Endpoint is created on all clusters using [Managed Cluster Config](https://github.com/openshift/managed-cluster-config/tree/master/deploy/osd-avo-resources/fedramp-vpc-endpoints). 
+
+Tangentially, AVO has a Namespace file in the FedRAMP App Interface to manage other crucial configurations:
+* A ConfigMap with an AvoConfig object to enable the acceptance controller on Hives
+* Two VpcEndpointAcceptance objects to handle auto-acceptance for our Splunk VPC Endpoint Service in either Gov Region
+
 # Development
 
 Looking to work on this? See [dev/README.md](./dev/README.md)

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -15,9 +15,6 @@ parameters:
 - name: DISPLAY_NAME
   value: AWS VPCE Operator
   required: true
-- name: ENABLE_VPC_ACCEPTANCE  
-  value: "false"
-  required: true
 metadata:
   name: selectorsyncset-template
 objects:
@@ -152,32 +149,3 @@ objects:
         name: ${REPO_NAME}
         source: ${REPO_NAME}-registry
         sourceNamespace: openshift-${REPO_NAME}
-# config for hives only to enable VpcEndpointAcceptance        
-- apiVersion: hive.openshift.io/v1
-  kind: SelectorSyncSet
-  metadata:
-    name: aws-vpce-operator-frhive-sss
-  spec:
-    clusterDeploymentSelector:
-      matchExpressions:
-        - key: api.openshift.com/fedramp
-          operator: In
-          values:
-            - "true"
-        - key: ext-managed.openshift.io/hive-shard
-          operator: In
-          values:
-            - "true"
-    resourceApplyMode: Sync
-    resources:                    
-    - apiVersion: v1
-      data:
-        avo_config.yaml: |-
-          apiVersion: avo.openshift.io/v1alpha1
-          kind: AvoConfig
-          enableVpcEndpointController: true
-          enableVpcEndpointAcceptanceController: ${ENABLE_VPC_ACCEPTANCE}
-      kind: ConfigMap
-      metadata:
-        name: avo-config
-        namespace: openshift-${REPO_NAME}


### PR DESCRIPTION
- Removes the AvoConfig ConfigMap from olm template as this is being moved into FR App Interface using Namespace files
- Updates the README to highlight the locations of various configurations for this operator for the FedRAMP environment