### PR TITLE
Refactor env var checks into Go

### DIFF
--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -17,6 +17,9 @@ limitations under the License.
 package util
 
 import (
+	"fmt"
+	"net/http"
+	"os"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -53,4 +56,24 @@ func DefaultAVORateLimiter() workqueue.RateLimiter {
 		// 10 qps, 100 bucket size, only for overall retry limiting (not per item)
 		&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(10, 100)},
 	)
+}
+
+// AWSEnvVarReadyzChecker is a healthz.Checker that returns an error if there are not enough environment variables
+// set to create an AWS client for this operator to function.
+func AWSEnvVarReadyzChecker(_ *http.Request) error {
+	// These two in combination allow non-STS clusters to get the necessary credentials
+	if _, ok := os.LookupEnv("AWS_SECRET_ACCESS_KEY"); ok {
+		if _, ok := os.LookupEnv("AWS_ACCESS_KEY_ID"); ok {
+			return nil
+		}
+	}
+
+	// These two in combination allow STS clusters to get the necessary credentials
+	if _, ok := os.LookupEnv("AWS_WEB_IDENTITY_TOKEN_FILE"); ok {
+		if _, ok := os.LookupEnv("AWS_ROLE_ARN"); ok {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("missing sufficient environment variables to build an AWS client")
 }

--- a/controllers/util/util_test.go
+++ b/controllers/util/util_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"net/http"
 	"testing"
 	"time"
 )
@@ -38,5 +39,56 @@ func TestDefaultAVORateLimiter(t *testing.T) {
 	}
 	if expected, actual := 4, limiter.NumRequeues("test"); expected != actual {
 		t.Errorf("expected %v, got %v", expected, actual)
+	}
+}
+
+func TestAWSEnvVarReadyzChecker(t *testing.T) {
+	tests := []struct {
+		name      string
+		env       map[string]string
+		expectErr bool
+	}{
+		{
+			name: "non-STS",
+			env: map[string]string{
+				"AWS_SECRET_ACCESS_KEY": "A",
+				"AWS_ACCESS_KEY_ID":     "B",
+			},
+			expectErr: false,
+		},
+		{
+			name: "STS",
+			env: map[string]string{
+				"AWS_WEB_IDENTITY_TOKEN_FILE": "A",
+				"AWS_ROLE_ARN":                "B",
+			},
+			expectErr: false,
+		},
+		{
+			name: "insufficient",
+			env: map[string]string{
+				"AWS_SECRET_ACCESS_KEY": "A",
+				"SOMETHING_ELSE":        "B",
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for k, v := range test.env {
+				t.Setenv(k, v)
+			}
+			actual := AWSEnvVarReadyzChecker(&http.Request{})
+			if actual != nil {
+				if !test.expectErr {
+					t.Fatalf("expected no error, got %s", actual)
+				}
+			} else {
+				if test.expectErr {
+					t.Fatalf("expected error, got nil")
+				}
+			}
+		})
 	}
 }

--- a/deploy/20_operator.yaml
+++ b/deploy/20_operator.yaml
@@ -63,19 +63,15 @@ spec:
             limits:
               memory: "1G"
           livenessProbe:
-            exec:
-              command: 
-              - /bin/bash
-              - -c 
-              - '[[ (! -z "$AWS_SECRET_ACCESS_KEY" && ! -z "$AWS_ACCESS_KEY_ID") || (! -z "$AWS_ROLE_ARN" && ! -z "$AWS_WEB_IDENTITY_TOKEN_FILE") ]]'
+            httpGet:
+              path: /healthz
+              port: 8081
             initialDelaySeconds: 15
             periodSeconds: 20
           readinessProbe:
-            exec:
-              command: 
-              - /bin/bash
-              - -c 
-              - '[[ (! -z "$AWS_SECRET_ACCESS_KEY" && ! -z "$AWS_ACCESS_KEY_ID") || (! -z "$AWS_ROLE_ARN" && ! -z "$AWS_WEB_IDENTITY_TOKEN_FILE") ]]'
+            httpGet:
+              path: /readyz
+              port: 8081
             initialDelaySeconds: 5
             periodSeconds: 10
           securityContext:


### PR DESCRIPTION
[OSD-13739](https://issues.redhat.com//browse/OSD-13739)

Related to #56, this moves the checks into Go to remove the dependency on bash and puts back the default (previously thought of as useless) livenessProbe.

The livenessProbe does have value if this operator ever panics/gets killed - in the current setup the livenessProbe would continue passing as long as environment variables were set. Putting the default one back allows Kubernetes to notice and cycle the pod in this scenario instead. Validated this works in an integration environment.