### PR TITLE
Correctly handle case when no vpce need accepting

### DIFF
--- a/controllers/vpcendpointacceptance/vpcendpointacceptance_controller.go
+++ b/controllers/vpcendpointacceptance/vpcendpointacceptance_controller.go
@@ -117,7 +117,7 @@ func (r *VpcEndpointAcceptanceReconciler) Reconcile(ctx context.Context, req ctr
 	}
 
 	// If valid, accept the VPCE connection
-	if _, err := r.awsClient.AcceptVpcEndpointConnection(ctx, vpceAcceptance.Spec.Id, vpceToAccept...); err != nil {
+	if _, err := r.awsClient.AcceptVpcEndpointConnections(ctx, vpceAcceptance.Spec.Id, vpceToAccept...); err != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/pkg/aws_client/client.go
+++ b/pkg/aws_client/client.go
@@ -78,8 +78,17 @@ func NewAwsClientWithServiceClients(ec2 AvoEC2API, r53 AvoRoute53API) *AWSClient
 	}
 }
 
+// NewVpcEndpointAcceptanceAwsClient returns an VpcEndpointAcceptanceAWSClient with the provided session
 func NewVpcEndpointAcceptanceAwsClient(cfg aws.Config) *VpcEndpointAcceptanceAWSClient {
 	return &VpcEndpointAcceptanceAWSClient{
 		ec2Client: ec2.NewFromConfig(cfg),
+	}
+}
+
+// NewVpcEndpointAcceptanceAwsClientWithServiceClients returns a VpcEndpointAcceptanceAWSClient with the provided
+// EC2 client. Typically, not used directly except for building a mock for testing.
+func NewVpcEndpointAcceptanceAwsClientWithServiceClients(ec2 AvoVpcEndpointAcceptanceEc2Api) *VpcEndpointAcceptanceAWSClient {
+	return &VpcEndpointAcceptanceAWSClient{
+		ec2Client: ec2,
 	}
 }

--- a/pkg/aws_client/mock.go
+++ b/pkg/aws_client/mock.go
@@ -18,7 +18,7 @@ package aws_client
 
 import (
 	"context"
-
+	"fmt"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
@@ -36,6 +36,7 @@ const (
 	MockSecurityGroupId        = "sg-12345"
 	MockVpcId                  = "vpc-12345"
 	MockVpcEndpointServiceName = "com.amazonaws.vpce.service.mock-12345"
+	MockVpcEndpointServiceId   = "vpce-svc-12345"
 )
 
 type MockedEC2 struct {
@@ -98,6 +99,10 @@ func NewMockedEC2WithSubnets() *MockedEC2 {
 
 func NewMockedAwsClient() *AWSClient {
 	return NewAwsClientWithServiceClients(&MockedEC2{}, &MockedRoute53{})
+}
+
+func NewMockedVpceAcceptanceAwsClient() *VpcEndpointAcceptanceAWSClient {
+	return NewVpcEndpointAcceptanceAwsClientWithServiceClients(&MockedEC2{})
 }
 
 func NewMockedAwsClientWithSubnets() *AWSClient {
@@ -234,6 +239,19 @@ func (m *MockedEC2) CreateVpcEndpoint(ctx context.Context, params *ec2.CreateVpc
 			VpcEndpointId: aws.String(testutil.MockVpcEndpointId),
 		},
 	}, nil
+}
+
+func (m *MockedEC2) AcceptVpcEndpointConnections(ctx context.Context, params *ec2.AcceptVpcEndpointConnectionsInput, optFns ...func(*ec2.Options)) (*ec2.AcceptVpcEndpointConnectionsOutput, error) {
+	if len(params.VpcEndpointIds) == 0 {
+		return nil, fmt.Errorf("1 validation error(s) found.\n- missing required field")
+	}
+
+	return &ec2.AcceptVpcEndpointConnectionsOutput{}, nil
+}
+
+func (m *MockedEC2) DescribeVpcEndpointConnections(ctx context.Context, params *ec2.DescribeVpcEndpointConnectionsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVpcEndpointConnectionsOutput, error) {
+	// TODO: This is a no-op
+	return &ec2.DescribeVpcEndpointConnectionsOutput{}, nil
 }
 
 func (m *MockedEC2) DeleteVpcEndpoints(ctx context.Context, params *ec2.DeleteVpcEndpointsInput, optFns ...func(*ec2.Options)) (*ec2.DeleteVpcEndpointsOutput, error) {

--- a/pkg/aws_client/vpc_endpoint_service.go
+++ b/pkg/aws_client/vpc_endpoint_service.go
@@ -47,7 +47,13 @@ func (c *VpcEndpointAcceptanceAWSClient) GetVpcEndpointConnectionsPendingAccepta
 	return c.ec2Client.DescribeVpcEndpointConnections(ctx, input)
 }
 
-func (c *VpcEndpointAcceptanceAWSClient) AcceptVpcEndpointConnection(ctx context.Context, serviceId string, vpcEndpointIds ...string) (*ec2.AcceptVpcEndpointConnectionsOutput, error) {
+// AcceptVpcEndpointConnections is a wrapper around ec2:AcceptVpcEndpointConnections for a give VPC Endpoint serviceId
+// and a slice of vpcEndpointIds
+func (c *VpcEndpointAcceptanceAWSClient) AcceptVpcEndpointConnections(ctx context.Context, serviceId string, vpcEndpointIds ...string) (*ec2.AcceptVpcEndpointConnectionsOutput, error) {
+	if len(vpcEndpointIds) == 0 {
+		return &ec2.AcceptVpcEndpointConnectionsOutput{}, nil
+	}
+
 	input := &ec2.AcceptVpcEndpointConnectionsInput{
 		ServiceId:      aws.String(serviceId),
 		VpcEndpointIds: vpcEndpointIds,

--- a/pkg/aws_client/vpc_endpoint_service_test.go
+++ b/pkg/aws_client/vpc_endpoint_service_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws_client
+
+import (
+	"context"
+	"testing"
+)
+
+func TestVpcEndpointAcceptanceAWSClient_AcceptVpcEndpointConnections(t *testing.T) {
+	tests := []struct {
+		name      string
+		vpceIds   []string
+		expectErr bool
+	}{
+		{
+			name:      "nothing to accept",
+			vpceIds:   []string{},
+			expectErr: false,
+		},
+		{
+			name:      "something to accept",
+			vpceIds:   []string{"vpce-12345"},
+			expectErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := NewMockedVpceAcceptanceAwsClient()
+			_, err := client.AcceptVpcEndpointConnections(context.TODO(), MockVpcEndpointServiceId, test.vpceIds...)
+			if err != nil {
+				if !test.expectErr {
+					t.Fatalf("expected no error, but got %s", err)
+				}
+			} else {
+				if test.expectErr {
+					t.Fatal("expected error, but got none")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Per OSD-13743, the `vpceacceptance` controller has been spinning when there are no vpc endpoints to accept:

```json
{"level":"error","ts":"2022-11-10T15:04:20Z","msg":"Reconciler error","controller":"vpcendpointacceptance","controllerGroup":"avo.openshift.io","controllerKind":"VpcEndpointAcceptance","vpcEndpointAcceptance":{"name":"osd-fr-splunk-acceptance-uge","namespace":"openshift-aws-vpce-operator"},"namespace":"openshift-aws-vpce-operator","name":"osd-fr-splunk-acceptance-uge","reconcileID":"82957471-cad6-45b1-84af-f1bed5e31634","error":"operation error EC2: AcceptVpcEndpointConnections, 1 validation error(s) found.\n- missing required field, AcceptVpcEndpointConnectionsInput.VpcEndpointIds.\n","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\tpkg/mod/sigs.k8s.io/controller-runtime@v0.12.2/pkg/internal/controller/controller.go:273\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\tpkg/mod/sigs.k8s.io/controller-runtime@v0.12.2/pkg/internal/controller/controller.go:234"}
```

This fixes that/adds a test for it