### PR TITLE
Remove additional required tag: `kubernetes.io/role/internal-elb`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ If auto-acceptance is disabled on the VPC Endpoint Service, then the VPC Endpoin
 
 AVO currently assumes it is running on an AWS OpenShift cluster, specifically:
 
-* The cluster's private subnets are tagged with `kubernetes.io/role/internal-elb` (not currently enforced for BYOVPC clusters)
 * The existence of a `infrastructures.config.openshift.io` CR named `default`
 * The existence of a `dnses.config.openshift.io` CR named `default`
 * Minimum K8s RBAC defined [here](./deploy/15_clusterrole.yaml)

--- a/controllers/vpcendpoint/helpers.go
+++ b/controllers/vpcendpoint/helpers.go
@@ -419,7 +419,7 @@ func (r *VpcEndpointReconciler) diffVpcEndpointSubnets(ctx context.Context, vpce
 		return nil, nil, fmt.Errorf("unable to parse cluster tag: %v", r.clusterInfo)
 	}
 
-	subnetsResp, err := r.awsClient.DescribePrivateSubnets(ctx, r.clusterInfo.clusterTag)
+	subnetsResp, err := r.awsClient.GetRosaVpceSubnets(ctx, r.clusterInfo.clusterTag)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/controllers/vpcendpoint/helpers_test.go
+++ b/controllers/vpcendpoint/helpers_test.go
@@ -348,25 +348,15 @@ func TestVpcEndpointReconciler_diffVpcEndpointSubnets(t *testing.T) {
 			expectedNumToRemove: 0,
 			expectErr:           false,
 		},
-		{
-			name:       "subnet removal needed",
-			clusterTag: "some/random/tag",
-			vpce: &ec2Types.VpcEndpoint{
-				SubnetIds: []string{aws_client.MockPrivateSubnetId},
-			},
-			expectedNumToAdd:    0,
-			expectedNumToRemove: 1,
-			expectErr:           false,
-		},
 	}
 
 	for _, test := range tests {
-		r := &VpcEndpointReconciler{
-			awsClient:   aws_client.NewMockedAwsClientWithSubnets(),
-			log:         testr.New(t),
-			clusterInfo: &clusterInfo{clusterTag: test.clusterTag},
-		}
 		t.Run(test.name, func(t *testing.T) {
+			r := &VpcEndpointReconciler{
+				awsClient:   aws_client.NewMockedAwsClientWithSubnets(),
+				log:         testr.New(t),
+				clusterInfo: &clusterInfo{clusterTag: test.clusterTag},
+			}
 			actualToAdd, actualToRemove, err := r.diffVpcEndpointSubnets(context.TODO(), test.vpce)
 			if test.expectErr {
 				assert.Error(t, err)

--- a/pkg/aws_client/mock.go
+++ b/pkg/aws_client/mock.go
@@ -77,17 +77,8 @@ var mockSubnets = []*ec2Types.Subnet{
 	},
 	{
 		SubnetId: aws.String(MockPublicSubnetId),
-		Tags: []ec2Types.Tag{
-			{
-				Key:   aws.String(publicSubnetTagKey),
-				Value: nil,
-			},
-			{
-				Key:   aws.String(MockClusterTag),
-				Value: aws.String("shared"),
-			},
-		},
-		VpcId: aws.String(MockVpcId),
+		Tags:     []ec2Types.Tag{},
+		VpcId:    aws.String(MockVpcId),
 	},
 }
 

--- a/pkg/aws_client/subnet_test.go
+++ b/pkg/aws_client/subnet_test.go
@@ -19,54 +19,37 @@ package aws_client
 import (
 	"context"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestAWSClient_DescribeSubnets(t *testing.T) {
 	tests := []struct {
-		clusterTag        string
-		expectedPrivateId string
-		expectedPublicId  string
-		expectedVpcId     string
-		expectErr         bool
+		clusterTag string
+		expectErr  bool
 	}{
 		{
-			clusterTag:        MockClusterTag,
-			expectedPrivateId: MockPrivateSubnetId,
-			expectedPublicId:  MockPublicSubnetId,
-			expectedVpcId:     MockVpcId,
-			expectErr:         false,
+			clusterTag: MockClusterTag,
+			expectErr:  false,
+		},
+		{
+			clusterTag: "doesn't exist",
+			expectErr:  true,
 		},
 	}
 
 	client := NewMockedAwsClientWithSubnets()
 
 	for _, test := range tests {
-		actualPrivate, err := client.DescribePrivateSubnets(context.TODO(), test.clusterTag)
-		if test.expectErr {
-			assert.NotNil(t, err)
-		} else {
-			assert.Nil(t, err)
-			assert.Equal(t, len(actualPrivate.Subnets), 1)
-			assert.Equal(t, test.expectedPrivateId, *actualPrivate.Subnets[0].SubnetId)
-		}
-
-		actualPublic, err := client.DescribePublicSubnets(context.TODO(), test.clusterTag)
-		if test.expectErr {
-			assert.NotNil(t, err)
-		} else {
-			assert.Nil(t, err)
-			assert.Equal(t, len(actualPublic.Subnets), 1)
-			assert.Equal(t, test.expectedPublicId, *actualPublic.Subnets[0].SubnetId)
-		}
-
-		actualVpcId, err := client.GetVPCId(context.TODO(), test.clusterTag)
-		if test.expectErr {
-			assert.NotNil(t, err)
-		} else {
-			assert.Nil(t, err)
-			assert.Equal(t, test.expectedVpcId, actualVpcId)
-		}
+		t.Run(test.clusterTag, func(t *testing.T) {
+			_, err := client.GetRosaVpceSubnets(context.TODO(), test.clusterTag)
+			if err != nil {
+				if !test.expectErr {
+					t.Errorf("expected no error, got %s", err)
+				}
+			} else {
+				if test.expectErr {
+					t.Error("expected error, got nil")
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Per OSD-13916, we don't really need the `kubernetes.io/role/internal-elb` tag because:

* For PrivateLink clusters, only the private subnets have this tag
* For non-BYOVPC clusters, we can rely on hive to tag `kubernetes.io/role/internal-elb` correctly
* This makes the operator attach VPCEs to private + public subnets for BYOVPC, non-PrivateLink clusters, but I think that's ok. It just makes traffic from their public subnets also go through the VPCE instead of an IGW.
* (Maybe most importantly) we just can't count on end-users to tag their VPC correctly