### PR TITLE
Only deploy to privatelink mgmt/service clusters

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -173,6 +173,9 @@ objects:
         - key: api.openshift.com/fedramp
           operator: NotIn
           values: "true"
+        - key: api.openshift.com/private-link
+          operator: In 
+          values: ["true"]
     resourceApplyMode: Sync
     resources:
     - kind: Namespace
@@ -307,6 +310,9 @@ objects:
           values: ["management-cluster"]
         - key: api.openshift.com/fedramp
           operator: NotIn
+          values: ["true"]
+        - key: api.openshift.com/private-link
+          operator: In 
           values: ["true"]
     resourceApplyMode: Sync
     resources:


### PR DESCRIPTION
For management/service clusters, only deploy AVO SSS if they are PrivateLink as well