### PR TITLE
OLM template syntax bugfix

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -173,9 +173,6 @@ objects:
         - key: api.openshift.com/fedramp
           operator: NotIn
           values: ["true"]
-        - key: api.openshift.com/private-link
-          operator: In
-          values: ["true"]
     resourceApplyMode: Sync
     resources:
     - kind: Namespace
@@ -310,9 +307,6 @@ objects:
           values: ["management-cluster"]
         - key: api.openshift.com/fedramp
           operator: NotIn
-          values: ["true"]
-        - key: api.openshift.com/private-link
-          operator: In
           values: ["true"]
     resourceApplyMode: Sync
     resources:

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -172,9 +172,9 @@ objects:
           values: ["service-cluster"]
         - key: api.openshift.com/fedramp
           operator: NotIn
-          values: "true"
+          values: ["true"]
         - key: api.openshift.com/private-link
-          operator: In 
+          operator: In
           values: ["true"]
     resourceApplyMode: Sync
     resources:
@@ -312,7 +312,7 @@ objects:
           operator: NotIn
           values: ["true"]
         - key: api.openshift.com/private-link
-          operator: In 
+          operator: In
           values: ["true"]
     resourceApplyMode: Sync
     resources:


### PR DESCRIPTION
The SSS is currently failing to roll out due to:

```
[2022-12-15 16:12:53] [INFO] [openshift_base.py:apply:329] - ['apply', 'hive-stage-01', 'cluster-scope', 'SelectorSyncSet', 'aws-vpce-operator']
[2022-12-15 16:12:55] [INFO] [openshift_base.py:apply:329] - ['apply', 'hive-stage-01', 'cluster-scope', 'SelectorSyncSet', 'aws-vpce-operator-svc-sss']
[2022-12-15 16:13:56] [ERROR] [openshift_base.py:_realize_resource_data:638] - [hive-stage-01/cluster-scope] [https://api.hive-stage-01.n1u3.p1.openshiftapps.com:6443/]: The SelectorSyncSet "aws-vpce-operator-svc-sss" is invalid: spec.clusterDeploymentSelector.matchExpressions[1].values: Invalid value: "string": spec.clusterDeploymentSelector.matchExpressions[1].values in body must be of type array: "string"
 (error details: https://github.com/openshift/aws-vpce-operator/blob/main/hack/olm-registry/olm-artifacts-template.yaml)
[2022-12-15 16:13:56] [INFO] [openshift_base.py:apply:329] - ['apply', 'hive-stage-01', 'cluster-scope', 'SelectorSyncSet', 'aws-vpce-operator-mgmt-sss']
```

Also removing the `private-link` restriction to enable easier testing.