### PR TITLE
OSD-13509: AVO support to create private zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ AVO is an OpenShift operator that manages connectivity to private VPC Endpoint S
 
 [![codecov](https://codecov.io/gh/openshift/aws-vpce-operator/branch/main/graph/badge.svg)](https://codecov.io/gh/openshift/aws-vpce-operator)
 
-# Usage
+## Usage
 
 In a practical sense, given a service that is exposed via an AWS VPC Endpoint Service (i.e. not exposed over the public internet), the [VpcEndpoint CRD](./deploy/crds/avo.openshift.io_vpcendpoints.yaml) defines an API to configure three components in a customer cluster to create network connectivity between components in a customer cluster and the private VPC Endpoint Service, illustrated below.
 
@@ -24,7 +24,7 @@ graph LR
 
 If auto-acceptance is disabled on the VPC Endpoint Service, then the VPC Endpoint will be in a `pendingAcceptance` state until the connection is accepted inside the service hosting account. Work is being done to provide an automated solution for this acceptance!
 
-## Requirements
+### Requirements
 
 AVO currently assumes it is running on an AWS OpenShift cluster, specifically:
 
@@ -34,7 +34,7 @@ AVO currently assumes it is running on an AWS OpenShift cluster, specifically:
 * Minimum K8s RBAC defined [here](./deploy/15_clusterrole.yaml)
 * Minimum AWS IAM Policy:
 
-    ```json
+```json
     {
       "Version": "2012-10-17",
       "Statement": [
@@ -51,21 +51,26 @@ AVO currently assumes it is running on an AWS OpenShift cluster, specifically:
             "ec2:AuthorizeSecurityGroupIngress",
             "ec2:AuthorizeSecurityGroupEgress",
             "ec2:DescribeSecurityGroupRules",
+            "ec2:DescribeVpcs",
             "ec2:CreateVpcEndpoint",
             "ec2:DeleteVpcEndpoints",
             "ec2:DescribeVpcEndpoints",
             "ec2:ModifyVpcEndpoint",
             "route53:ChangeResourceRecordSets",
             "route53:ListHostedZonesByName",
-            "route53:ListResourceRecordSets"
+            "route53:ListResourceRecordSets",
+            "route53:ListTagsForResource",
+            "route53:GetHostedZone",
+            "route53:CreateHostedZone",
+            "route53:ChangeTagsForResource"
           ],
           "Resource": "*"
         }
       ]
     }
-    ```
+```
 
-# Custom Resource Definitions (CRDs)
+## Custom Resource Definitions (CRDs)
 
 ## VpcEndpoint
 
@@ -86,6 +91,7 @@ spec:
         protocol: "tcp"
   serviceName: "com.amazonaws.vpce.us-east-1.vpce-svc-00000000000000000"
   subdomainName: "examplesubdomain"
+  addtlHostedZoneName: "supplemental.routing.tld" #Optional
 ```
 
 * `.spec.serviceName` is the name of the VPC Endpoint Service to connect to
@@ -93,6 +99,7 @@ spec:
 * `.spec.subdomainName` generates a Route53 CNAME record in the cluster's Private Hosted Zone in the form of `${subdomainName}.${clusterBaseDomain}` pointing to the VPC Endpoint Regional DNS Name.
 * `.spec.externalNameService` defines the name and namespace the ExternalName service that will be created pointing to the Route53 record created above.
 * `.spec.securityGroup` defines security group ingress and egress rules that will be attached to the created VPC Endpoint
+* `.spec.addtlHostedZoneName` is an optional fully qualified domain name used for supplemental Private Hosted Zone(s) to accommodate records outside of the `${clusterBaseDomain}`
 
 ## VpcEndpointAcceptance
 
@@ -116,14 +123,15 @@ spec:
 * `.spec.assumeRoleArn` is the IAM role in the account of the Endpoint Service that grants permission to handle acceptance
 * `.spec.region` is the AWS region where the Endpoint Service resides
 
-# FedRAMP Cluster Deployments
+## FedRAMP Cluster Deployments
 
-AVO is currently deployed to all FedRAMP clusters through App Interface using the template in this repo and OLM. To ensure clusters are automatically configured for Splunk log forwarding, a VPC Endpoint is created on all clusters using [Managed Cluster Config](https://github.com/openshift/managed-cluster-config/tree/master/deploy/osd-avo-resources/fedramp-vpc-endpoints). 
+AVO is currently deployed to all FedRAMP clusters through App Interface using the template in this repo and OLM. To ensure clusters are automatically configured for Splunk log forwarding, a VPC Endpoint is created on all clusters using [Managed Cluster Config](https://github.com/openshift/managed-cluster-config/tree/master/deploy/osd-avo-resources/fedramp-vpc-endpoints).
 
 Tangentially, AVO has a Namespace file in the FedRAMP App Interface to manage other crucial configurations:
+
 * A ConfigMap with an AvoConfig object to enable the acceptance controller on Hives
 * Two VpcEndpointAcceptance objects to handle auto-acceptance for our Splunk VPC Endpoint Service in either Gov Region
 
-# Development
+## Development
 
 Looking to work on this? See [dev/README.md](./dev/README.md)

--- a/api/v1alpha1/vpcendpoint_types.go
+++ b/api/v1alpha1/vpcendpoint_types.go
@@ -64,6 +64,10 @@ type VpcEndpointSpec struct {
 
 	// ExternalNameService configures the name and namespace of the created Kubernetes ExternalName Service
 	ExternalNameService ExternalNameServiceSpec `json:"externalNameService"`
+
+	// AddtlHostedZoneName is an optional FQDN to support supplemental VPCE routing via Route53 Private Hosted Zone
+	// +optional
+	AddtlHostedZoneName string `json:"addtlHostedZoneName,omitempty"`
 }
 
 const (

--- a/controllers/vpcendpoint/vpcendpoint_controller.go
+++ b/controllers/vpcendpoint/vpcendpoint_controller.go
@@ -146,6 +146,13 @@ func (r *VpcEndpointReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, err
 	}
 
+	// Validate presence of addtlHostedZoneName
+	if avo.Spec.AddtlHostedZoneName != "" {
+		if err := r.validatePrivateHostedZone(ctx, avo); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
 	// Check again in 30 sec
 	return ctrl.Result{RequeueAfter: time.Second * 30}, nil
 }

--- a/deploy/crds/avo.openshift.io_vpcendpoints.yaml
+++ b/deploy/crds/avo.openshift.io_vpcendpoints.yaml
@@ -47,6 +47,10 @@ spec:
           spec:
             description: VpcEndpointSpec defines the desired state of VpcEndpoint
             properties:
+              addtlHostedZoneName:
+                description: AddtlHostedZoneName is an optional FQDN to support supplemental
+                  VPCE routing via Route53 Private Hosted Zone
+                type: string
               externalNameService:
                 description: ExternalNameService configures the name and namespace
                   of the created Kubernetes ExternalName Service

--- a/dev/vpce_hosted_zone_example.yml
+++ b/dev/vpce_hosted_zone_example.yml
@@ -1,0 +1,17 @@
+---
+apiVersion: avo.openshift.io/v1alpha1
+kind: VpcEndpoint
+metadata:
+  name: demo
+  namespace: demo
+spec:
+  subdomainName: "splunk"
+  serviceName: "com.amazonaws.vpce.us-west-2.vpce-svc-00000000000000000"
+  securityGroup:
+    ingressRules:
+      - fromPort: 9997
+        toPort: 9997
+        protocol: tcp
+  externalNameService:
+    name: examplesvcname
+  addtlHostedZoneName: "sometestingdoma.in"

--- a/pkg/aws_client/client.go
+++ b/pkg/aws_client/client.go
@@ -48,6 +48,10 @@ type AvoRoute53API interface {
 	ChangeResourceRecordSets(ctx context.Context, params *route53.ChangeResourceRecordSetsInput, optFns ...func(*route53.Options)) (*route53.ChangeResourceRecordSetsOutput, error)
 	ListHostedZonesByName(ctx context.Context, params *route53.ListHostedZonesByNameInput, optFns ...func(*route53.Options)) (*route53.ListHostedZonesByNameOutput, error)
 	ListResourceRecordSets(ctx context.Context, params *route53.ListResourceRecordSetsInput, optFns ...func(*route53.Options)) (*route53.ListResourceRecordSetsOutput, error)
+	CreateHostedZone(ctx context.Context, params *route53.CreateHostedZoneInput, optFns ...func(*route53.Options)) (*route53.CreateHostedZoneOutput, error)
+	GetHostedZone(ctx context.Context, params *route53.GetHostedZoneInput, optFns ...func(*route53.Options)) (*route53.GetHostedZoneOutput, error)
+	ListTagsForResource(ctx context.Context, params *route53.ListTagsForResourceInput, optFns ...func(*route53.Options)) (*route53.ListTagsForResourceOutput, error)
+	ChangeTagsForResource(ctx context.Context, input *route53.ChangeTagsForResourceInput, optFns ...func(*route53.Options)) (*route53.ChangeTagsForResourceOutput, error)
 }
 
 type AWSClient struct {

--- a/pkg/aws_client/tags.go
+++ b/pkg/aws_client/tags.go
@@ -18,11 +18,21 @@ package aws_client
 
 import (
 	"context"
-
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
 )
 
 // CreateTags creates tags in an idempotent fashion
 func (c *AWSClient) CreateTags(ctx context.Context, input *ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error) {
 	return c.ec2Client.CreateTags(ctx, input)
+}
+
+// ListTagsForResource will fetch tags of a hosted zone or healthcheck
+func (c *AWSClient) ListTagsForResource(ctx context.Context, params *route53.ListTagsForResourceInput) (*route53.ListTagsForResourceOutput, error) {
+	return c.route53Client.ListTagsForResource(ctx, params)
+}
+
+// ChangeTagsForResource adds, edits, or deletes tags for a health check or a hosted zone.
+func (c *AWSClient) ChangeTagsForResource(ctx context.Context, params *route53.ChangeTagsForResourceInput) (*route53.ChangeTagsForResourceOutput, error) {
+	return c.route53Client.ChangeTagsForResource(ctx, params)
 }

--- a/pkg/util/naming.go
+++ b/pkg/util/naming.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	route53Types "github.com/aws/aws-sdk-go-v2/service/route53/types"
 )
 
 const (
@@ -107,4 +108,22 @@ func generateName(prefix string, suffix string, maxLength int) (string, error) {
 	}
 
 	return fmt.Sprintf("%s-%s", prefix, suffix), nil
+}
+
+// GenerateR53Tags returns the tags that should be reconciled on every AWS resource created by this operator
+func GenerateR53Tags(clusterTagKey string) ([]route53Types.Tag, error) {
+	if clusterTagKey == "" {
+		return nil, errors.New("clusterTagKey must not be empty")
+	}
+
+	return []route53Types.Tag{
+		{
+			Key:   aws.String(OperatorTagKey),
+			Value: aws.String(OperatorTagValue),
+		},
+		{
+			Key:   aws.String(clusterTagKey),
+			Value: aws.String("owned"),
+		},
+	}, nil
 }


### PR DESCRIPTION
New field added to the VPCE spec to support AVO's creation and tagging of route53 additional hosted private zones.