### PR TITLE
Additional tags on EC2 and R53 resources created by AVO

### DIFF
--- a/pkg/aws_client/client.go
+++ b/pkg/aws_client/client.go
@@ -49,7 +49,6 @@ type AvoRoute53API interface {
 	ListHostedZonesByName(ctx context.Context, params *route53.ListHostedZonesByNameInput, optFns ...func(*route53.Options)) (*route53.ListHostedZonesByNameOutput, error)
 	ListResourceRecordSets(ctx context.Context, params *route53.ListResourceRecordSetsInput, optFns ...func(*route53.Options)) (*route53.ListResourceRecordSetsOutput, error)
 	CreateHostedZone(ctx context.Context, params *route53.CreateHostedZoneInput, optFns ...func(*route53.Options)) (*route53.CreateHostedZoneOutput, error)
-	GetHostedZone(ctx context.Context, params *route53.GetHostedZoneInput, optFns ...func(*route53.Options)) (*route53.GetHostedZoneOutput, error)
 	ListTagsForResource(ctx context.Context, params *route53.ListTagsForResourceInput, optFns ...func(*route53.Options)) (*route53.ListTagsForResourceOutput, error)
 	ChangeTagsForResource(ctx context.Context, input *route53.ChangeTagsForResourceInput, optFns ...func(*route53.Options)) (*route53.ChangeTagsForResourceOutput, error)
 }

--- a/pkg/util/naming.go
+++ b/pkg/util/naming.go
@@ -29,6 +29,8 @@ const (
 	OperatorTagKey           = "kubernetes.io/aws-vpce-operator"
 	OperatorTagValue         = "managed"
 	SecurityGroupDescription = "Managed by AWS VPCE Operator"
+	RedHatManagedKey         = "red-hat-managed"
+	RedHatManagedValue       = "true"
 )
 
 // GenerateAwsTags returns the tags that should be reconciled on every AWS resource
@@ -50,6 +52,10 @@ func GenerateAwsTags(name, clusterTagKey string) ([]types.Tag, error) {
 		{
 			Key:   aws.String("Name"),
 			Value: aws.String(name),
+		},
+		{
+			Key:   aws.String(RedHatManagedKey),
+			Value: aws.String(RedHatManagedValue),
 		},
 	}, nil
 }
@@ -124,6 +130,10 @@ func GenerateR53Tags(clusterTagKey string) ([]route53Types.Tag, error) {
 		{
 			Key:   aws.String(clusterTagKey),
 			Value: aws.String("owned"),
+		},
+		{
+			Key:   aws.String(RedHatManagedKey),
+			Value: aws.String(RedHatManagedValue),
 		},
 	}, nil
 }


### PR DESCRIPTION
Updates the tags to EC2 and R53 Zones, removing an unused GetHostedZone function from the AvoRoute53API interface.