### PR TITLE
OSD-13910 Remove misleading controller-runtime stacktraces from errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -75,6 +75,8 @@ func main() {
 	opts := zap.Options{
 		Development: false,
 		TimeEncoder: zapcore.RFC3339TimeEncoder,
+		// Remove misleading controller-runtime stack traces https://github.com/kubernetes-sigs/kubebuilder/issues/1593
+		StacktraceLevel: zapcore.DPanicLevel,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()


### PR DESCRIPTION
Breaking this piece out of #95, I was observing that errors in logs always contain stack traces to controller-runtime which are never relevant (they never include the line of our own code that's failing, so they don't help with debugging).

This bug is noted upstream: https://github.com/kubernetes-sigs/kubebuilder/issues/1593 and this PR implements the described workaround.