### PR TITLE
Missing K8s RBAC

### DIFF
--- a/deploy/15_clusterrole.yaml
+++ b/deploy/15_clusterrole.yaml
@@ -62,3 +62,9 @@ rules:
     - patch
     - update
     - watch
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - create

--- a/deploy/30_prometheus_role.yaml
+++ b/deploy/30_prometheus_role.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-aws-vpce-operator
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch

--- a/deploy/30_prometheus_rolebinding.yaml
+++ b/deploy/30_prometheus_rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-aws-vpce-operator
+roleRef:
+  kind: Role
+  name: prometheus-k8s
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring


### PR DESCRIPTION
[OSD-13910](https://issues.redhat.com//browse/OSD-13910) This PR addresses two K8s RBAC errors relating to AVO:

The first is from Prometheus pods (`openshift-monitoring/prometheus-k8s-*`) that cannot scrape AVO metrics which seemingly was mistakenly removed in #42:

```
ts=2023-01-22T13:37:34.598Z caller=klog.go:108 level=warn component=k8s_client_runtime func=Warningf msg="github.com/prometheus/prometheus/discovery/kubernetes/kubernetes.go:541: failed to list *v1.Endpoints: endpoints is forbidden: User \"system:serviceaccount:openshift-monitoring:prometheus-k8s\" cannot list resource \"endpoints\" in API group \"\" in the namespace \"openshift-aws-vpce-operator\""
```

and the second is from AVO itself where it cannot create events, which was new functionality in #95:
```
E0124 21:26:46.400514       1 event.go:267] Server rejected event '&v1.Event{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"demo.173d5bd4e5cc747e", GenerateName:"", Namespace:"openshift-aws-vpce-operator", SelfLink:"", UID:"", ResourceVersion:"", Generation:0, CreationTimestamp:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), DeletionTimestamp:<nil>, DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ManagedFields:[]v1.ManagedFieldsEntry(nil)}, InvolvedObject:v1.ObjectReference{Kind:"VpcEndpoint", Namespace:"openshift-aws-vpce-operator", Name:"demo", UID:"a9f108f0-3df7-4b3f-b06c-006288f2fcb3", APIVersion:"avo.openshift.io/v1alpha2", ResourceVersion:"261614085", FieldPath:""}, Reason:"Created", Message:"Created Private Hosted Zone: /hostedzone/Z00130803CFL9MAWW3OUI", Source:v1.EventSource{Component:"VpcEndpoint", Host:""}, FirstTimestamp:time.Date(2023, time.January, 24, 21, 26, 46, 398268542, time.Local), LastTimestamp:time.Date(2023, time.January, 24, 21, 26, 46, 398268542, time.Local), Count:1, Type:"Normal", EventTime:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), Series:(*v1.EventSeries)(nil), Action:"", Related:(*v1.ObjectReference)(nil), ReportingController:"", ReportingInstance:""}': 'events is forbidden: User "system:serviceaccount:openshift-aws-vpce-operator:aws-vpce-operator" cannot create resource "events" in API group "" in the namespace "openshift-aws-vpce-operator"' (will not retry!) 
```

After validating both of these changes on stage clusters, Prometheus can scrape metrics again + events show up!

```
0s          Normal    Created               vpcendpoint/demo                                           Created security group: sg-0d77efb8a7982f542
0s          Normal    Created               vpcendpoint/demo                                           Created VPC endpoint: vpce-05181b93c2dee36ea
0s          Normal    Created               vpcendpoint/demo                                           Created Private Hosted Zone: /hostedzone/Z054667117956EYAG3OYG
```