### PR TITLE
AWSCredentialOverrideRef implementation

### DIFF
--- a/api/v1alpha2/vpcendpoint_types.go
+++ b/api/v1alpha2/vpcendpoint_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha2
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -86,7 +87,6 @@ type Route53PrivateHostedZone struct {
 	AutoDiscover bool `json:"autoDiscoverPrivateHostedZone,omitempty"`
 
 	// DomainName specifies the domain name of a Route 53 Private Hosted Zone to create
-	// TODO: Implement
 	DomainName string `json:"domainName,omitempty"`
 
 	// Id specifies the AWS ID of an existing Route 53 Private Hosted Zone to use
@@ -115,6 +115,12 @@ type VpcEndpointSpec struct {
 	// AssumeRoleArn will allow AVO to use sts:AssumeRole to create VPC Endpoints in separate AWS Accounts
 	// TODO: Implement
 	AssumeRoleArn string `json:"assumeRoleArn,omitempty"`
+
+	// +kubebuilder:validation:Optional
+
+	// AWSCredentialOverride is a Kubernetes secret containing AWS credentials for the operator to use for reconciling
+	// this specific vpcendpoint Custom Resource
+	AWSCredentialOverrideRef *corev1.SecretReference `json:"awsCredentialOverrideRef,omitempty"`
 
 	// +kubebuilder:validation:Optional
 

--- a/api/v1alpha2/zz_generated.deepcopy.go
+++ b/api/v1alpha2/zz_generated.deepcopy.go
@@ -6,7 +6,8 @@
 package v1alpha2
 
 import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -196,6 +197,11 @@ func (in *VpcEndpointList) DeepCopyObject() runtime.Object {
 func (in *VpcEndpointSpec) DeepCopyInto(out *VpcEndpointSpec) {
 	*out = *in
 	in.SecurityGroup.DeepCopyInto(&out.SecurityGroup)
+	if in.AWSCredentialOverrideRef != nil {
+		in, out := &in.AWSCredentialOverrideRef, &out.AWSCredentialOverrideRef
+		*out = new(v1.SecretReference)
+		**out = **in
+	}
 	in.Vpc.DeepCopyInto(&out.Vpc)
 	out.CustomDns = in.CustomDns
 }
@@ -215,7 +221,7 @@ func (in *VpcEndpointStatus) DeepCopyInto(out *VpcEndpointStatus) {
 	*out = *in
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
-		*out = make([]v1.Condition, len(*in))
+		*out = make([]metav1.Condition, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/deploy/17_role.yaml
+++ b/deploy/17_role.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: aws-vpce-operator-override-secret
+  namespace: openshift-aws-vpce-operator
+rules:
+  - apiGroups:
+    - ""
+    resources:
+    - secrets
+    verbs:
+    - get

--- a/deploy/18_rolebinding.yaml
+++ b/deploy/18_rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: aws-vpce-operator-override-secret
+  namespace: openshift-aws-vpce-operator
+subjects:
+  - kind: ServiceAccount
+    name: aws-vpce-operator
+    namespace: openshift-aws-vpce-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: aws-vpce-operator

--- a/deploy/crds/avo.openshift.io_vpcendpoints.yaml
+++ b/deploy/crds/avo.openshift.io_vpcendpoints.yaml
@@ -256,6 +256,21 @@ spec:
                 description: 'AssumeRoleArn will allow AVO to use sts:AssumeRole to
                   create VPC Endpoints in separate AWS Accounts TODO: Implement'
                 type: string
+              awsCredentialOverrideRef:
+                description: AWSCredentialOverride is a Kubernetes secret containing
+                  AWS credentials for the operator to use for reconciling this specific
+                  vpcendpoint Custom Resource
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
               customDns:
                 description: CustomDns will define configurations for all other custom
                   DNS setups, such as a separate Route 53 Private Hosted Zone or an
@@ -270,8 +285,8 @@ spec:
                           Route 53 Private Hosted Zone
                         type: boolean
                       domainName:
-                        description: 'DomainName specifies the domain name of a Route
-                          53 Private Hosted Zone to create TODO: Implement'
+                        description: DomainName specifies the domain name of a Route
+                          53 Private Hosted Zone to create
                         type: string
                       id:
                         description: Id specifies the AWS ID of an existing Route

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package secrets
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	defaultAWSAccessKeyId     = "aws_access_key_id"     //#nosec G101
+	defaultAWSSecretAccessKey = "aws_secret_access_key" //#nosec G101
+)
+
+// ParseAWSCredentialOverride takes in an AWS region and a secret reference and attempts to assemble an aws.Config
+// Currently only supports parsing AWS IAM User credentials
+func ParseAWSCredentialOverride(ctx context.Context, c client.Client, region string, ref *corev1.SecretReference) (aws.Config, error) {
+	if ref == nil {
+		return aws.Config{}, errors.New("AWS Credential Override secret reference must not be nil")
+	}
+
+	secret := new(corev1.Secret)
+	if err := c.Get(ctx, client.ObjectKey{Namespace: ref.Namespace, Name: ref.Name}, secret); err != nil {
+		return aws.Config{}, err
+	}
+
+	if b64AccessKeyId, ok := secret.Data[defaultAWSAccessKeyId]; ok {
+		if b64SecretAccessKey, ok := secret.Data[defaultAWSSecretAccessKey]; ok {
+			accessKeyId, err := base64.StdEncoding.DecodeString(string(b64AccessKeyId))
+			if err != nil {
+				return aws.Config{}, err
+			}
+
+			secretAccessKey, err := base64.StdEncoding.DecodeString(string(b64SecretAccessKey))
+			if err != nil {
+				return aws.Config{}, err
+			}
+
+			return config.LoadDefaultConfig(ctx,
+				config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(string(accessKeyId), string(secretAccessKey), "")),
+				config.WithRegion(region),
+			)
+		}
+	}
+
+	return aws.Config{}, fmt.Errorf("could not parse credential override secret, requires data keys %s and %s", defaultAWSAccessKeyId, defaultAWSSecretAccessKey)
+}

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package secrets
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+
+	"github.com/openshift/aws-vpce-operator/pkg/testutil"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	mockAWSAccessKeyId     = "mock_access_key_id"     //#nosec G101
+	mockAWSSecretAccessKey = "mock_secret_access_key" //#nosec G101
+)
+
+func TestParseAWSCredentialOverride(t *testing.T) {
+
+	tests := []struct {
+		secret    *corev1.Secret
+		expectErr bool
+	}{
+		{
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "override",
+					Namespace: "override-ns",
+				},
+				Data: map[string][]byte{
+					defaultAWSAccessKeyId:     []byte(base64.StdEncoding.EncodeToString([]byte(mockAWSAccessKeyId))),
+					defaultAWSSecretAccessKey: []byte(base64.StdEncoding.EncodeToString([]byte(mockAWSSecretAccessKey))),
+				},
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			mock := testutil.NewTestMock(t, test.secret)
+			ref := &corev1.SecretReference{
+				Name:      test.secret.Name,
+				Namespace: test.secret.Namespace,
+			}
+			cfg, err := ParseAWSCredentialOverride(context.TODO(), mock.Client, "us-east-1", ref)
+			if test.expectErr {
+				if err == nil {
+					t.Errorf("expected err, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no err, got %v", err)
+				}
+
+				creds, err := cfg.Credentials.Retrieve(context.TODO())
+				if err != nil {
+					t.Errorf("unexpected err: %v", err)
+				}
+
+				if creds.AccessKeyID != mockAWSAccessKeyId {
+					t.Errorf("expected %s, got %s", mockAWSAccessKeyId, creds.AccessKeyID)
+				}
+
+				if creds.SecretAccessKey != mockAWSSecretAccessKey {
+					t.Errorf("expected %s, got %s", mockAWSSecretAccessKey, creds.SecretAccessKey)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
[OSD-13906](https://issues.redhat.com//browse/OSD-13906)

This PR adds an optional `AWSCredentialOverrideRef` which allows for the operator to use specific secrets to override AWS credentials (for example, to create AWS resources in a separate AWS Account)

### K8s RBAC

Note that this requires the controller to be able to read secrets in all namespaces...