### PR TITLE
Use an APIReader so that we don't cache reads and can limit K8s RBAC

### DIFF
--- a/controllers/vpcendpoint/helpers.go
+++ b/controllers/vpcendpoint/helpers.go
@@ -82,7 +82,7 @@ func (r *VpcEndpointReconciler) parseClusterInfo(ctx context.Context, vpce *avov
 
 	if vpce.Spec.AWSCredentialOverrideRef != nil {
 		// Use the provided override credentials for this specific vpcendpoint
-		cfg, err := secrets.ParseAWSCredentialOverride(ctx, r.Client, r.clusterInfo.region, vpce.Spec.AWSCredentialOverrideRef)
+		cfg, err := secrets.ParseAWSCredentialOverride(ctx, r.APIReader, r.clusterInfo.region, vpce.Spec.AWSCredentialOverrideRef)
 		if err != nil {
 			return err
 		}

--- a/controllers/vpcendpoint/vpcendpoint_controller.go
+++ b/controllers/vpcendpoint/vpcendpoint_controller.go
@@ -40,8 +40,9 @@ import (
 // VpcEndpointReconciler reconciles a VpcEndpoint object
 type VpcEndpointReconciler struct {
 	client.Client
-	Scheme   *runtime.Scheme
-	Recorder record.EventRecorder
+	APIReader client.Reader
+	Scheme    *runtime.Scheme
+	Recorder  record.EventRecorder
 
 	log         logr.Logger
 	awsClient   *aws_client.AWSClient
@@ -151,6 +152,8 @@ func (r *VpcEndpointReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *VpcEndpointReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.APIReader = mgr.GetAPIReader()
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&avov1alpha2.VpcEndpoint{}).
 		Owns(&corev1.Service{}).

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -37,12 +37,14 @@ const (
 
 // ParseAWSCredentialOverride takes in an AWS region and a secret reference and attempts to assemble an aws.Config
 // Currently only supports parsing AWS IAM User credentials
-func ParseAWSCredentialOverride(ctx context.Context, c client.Client, region string, ref *corev1.SecretReference) (aws.Config, error) {
+func ParseAWSCredentialOverride(ctx context.Context, c client.Reader, region string, ref *corev1.SecretReference) (aws.Config, error) {
 	if ref == nil {
 		return aws.Config{}, errors.New("AWS Credential Override secret reference must not be nil")
 	}
 
 	secret := new(corev1.Secret)
+	// We use an APIReader instead of reading from the cache here so that the controller can minimize
+	// the K8s RBAC needed to only get secrets where desired
 	if err := c.Get(ctx, client.ObjectKey{Namespace: ref.Namespace, Name: ref.Name}, secret); err != nil {
 		return aws.Config{}, err
 	}


### PR DESCRIPTION
While validating OSD-13906, the controller runs into this error:

```
W0126 22:36:53.621890       1 reflector.go:424] pkg/mod/k8s.io/client-go@v0.25.0/tools/cache/reflector.go:169: failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:openshift-aws-vpce-operator:aws-vpce-operator" cannot list resource "secrets" in API group "" at the cluster scope
E0126 22:36:53.621924       1 reflector.go:140] pkg/mod/k8s.io/client-go@v0.25.0/tools/cache/reflector.go:169: Failed to watch *v1.Secret: failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:openshift-aws-vpce-operator:aws-vpce-operator" cannot list resource "secrets" in API group "" at the cluster scope 
```

Because `client.Client` tries to build a cache. This is generally a good thing and decreases load on etcd, but since aws-vpce-operator is cluster-scoped, it tries to build a cache of secrets at the cluster scope as well. As we would like to restrict the K8s RBAC for this controller to only be able to get secrets from `openshift-aws-vpce-operator` at this time, switching to a non-cached client, `client.Reader` is the way to do this.

Ref:
* https://github.com/kubernetes-sigs/controller-runtime/issues/144
* https://kubernetes.slack.com/archives/CAR30FCJZ/p1580118306075000