### PR TITLE
No need to base64 decode secret data with client-go

### DIFF
--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -18,7 +18,6 @@ package secrets
 
 import (
 	"context"
-	"encoding/base64"
 	"errors"
 	"fmt"
 
@@ -49,18 +48,8 @@ func ParseAWSCredentialOverride(ctx context.Context, c client.Reader, region str
 		return aws.Config{}, err
 	}
 
-	if b64AccessKeyId, ok := secret.Data[defaultAWSAccessKeyId]; ok {
-		if b64SecretAccessKey, ok := secret.Data[defaultAWSSecretAccessKey]; ok {
-			accessKeyId, err := base64.StdEncoding.DecodeString(string(b64AccessKeyId))
-			if err != nil {
-				return aws.Config{}, err
-			}
-
-			secretAccessKey, err := base64.StdEncoding.DecodeString(string(b64SecretAccessKey))
-			if err != nil {
-				return aws.Config{}, err
-			}
-
+	if accessKeyId, ok := secret.Data[defaultAWSAccessKeyId]; ok {
+		if secretAccessKey, ok := secret.Data[defaultAWSSecretAccessKey]; ok {
 			return config.LoadDefaultConfig(ctx,
 				config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(string(accessKeyId), string(secretAccessKey), "")),
 				config.WithRegion(region),

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -18,7 +18,6 @@ package secrets
 
 import (
 	"context"
-	"encoding/base64"
 	"testing"
 
 	"github.com/openshift/aws-vpce-operator/pkg/testutil"
@@ -32,7 +31,6 @@ const (
 )
 
 func TestParseAWSCredentialOverride(t *testing.T) {
-
 	tests := []struct {
 		secret    *corev1.Secret
 		expectErr bool
@@ -44,8 +42,8 @@ func TestParseAWSCredentialOverride(t *testing.T) {
 					Namespace: "override-ns",
 				},
 				Data: map[string][]byte{
-					defaultAWSAccessKeyId:     []byte(base64.StdEncoding.EncodeToString([]byte(mockAWSAccessKeyId))),
-					defaultAWSSecretAccessKey: []byte(base64.StdEncoding.EncodeToString([]byte(mockAWSSecretAccessKey))),
+					defaultAWSAccessKeyId:     []byte(mockAWSAccessKeyId),
+					defaultAWSSecretAccessKey: []byte(mockAWSSecretAccessKey),
 				},
 			},
 			expectErr: false,


### PR DESCRIPTION
[OSD-13907](https://issues.redhat.com//browse/OSD-13907) The following error was happening when attempting to use the AWS credential override:

```
{"level":"error","ts":"2023-01-27T18:30:10Z","msg":"Reconciler error","controller":"vpcendpoint","controllerGroup":"avo.openshift.io","controllerKind":"VpcEndpoint","VpcEndpoint":{"name":"avo-sc-test","namespace":"openshift-aws-vpce-operator"},"namespace":"openshift-aws-vpce-operator","name":"avo-sc-test","reconcileID":"5dad7071-549c-4136-9fa4-fed776605e88","error":"failed to describe subnets: operation error EC2: DescribeSubnets, exceeded maximum number of attempts, 3, https response error StatusCode: 0, RequestID: , request send failed, Post \"https://ec2.us-east-2.amazonaws.com/\": net/http: invalid header field value for \"Authorization\""} 
```

because we were doing an extra base64 decode... client-go returns the non-encoded value of the secret after converting `[]byte` to `string`