### PR TITLE
Fix bug where AVO was not creating a hosted zone the first time

### DIFF
--- a/controllers/vpcendpoint/helpers.go
+++ b/controllers/vpcendpoint/helpers.go
@@ -558,11 +558,8 @@ func (r *VpcEndpointReconciler) findOrCreatePrivateHostedZone(ctx context.Contex
 			return err
 		}
 
-		if len(resp.HostedZoneSummaries) == 0 {
-			return fmt.Errorf("no hosted zone found associated to VPC: %s in region: %s", r.clusterInfo.vpcId, r.clusterInfo.region)
-		}
-
 		for _, hz := range resp.HostedZoneSummaries {
+			// If we find a matching hosted zone, update status
 			if strings.TrimRight(*hz.Name, ".") == resource.Spec.CustomDns.Route53PrivateHostedZone.DomainName {
 				if resource.Status.HostedZoneId != *hz.HostedZoneId {
 					resource.Status.HostedZoneId = *hz.HostedZoneId
@@ -576,6 +573,7 @@ func (r *VpcEndpointReconciler) findOrCreatePrivateHostedZone(ctx context.Contex
 			}
 		}
 
+		// Otherwise, create one
 		createResp, err := r.awsClient.CreateHostedZone(ctx, resource.Spec.CustomDns.Route53PrivateHostedZone.DomainName, r.clusterInfo.vpcId, r.clusterInfo.region)
 		if err != nil {
 			return fmt.Errorf("failed to create hosted zone: %w", err)


### PR DESCRIPTION
[OSD-13906](https://issues.redhat.com//browse/OSD-13906)

This function has a bug the first time it runs because the Hosted Zone doesn't exist yet (it needs to be created) and caused the controller to get stuck in a loop printing out `no hosted zone found associated to VPC: %s in region: %s` because of it.

### Why wasn't this noticed before?

We were deploying additional Route53 Private Hosted Zones to VPCs that already had other Route 53 Private Hosted Zones associated with them, so there were always >= 1. In some cases, especially when using `awsCredentialOverrideRef`, there may not be any pre-existing associated Private Hosted Zones.
