### PR TITLE
Filtering autodiscovered subnets by availability zones supported by the VPCE Service

### DIFF
--- a/controllers/vpcendpoint/helpers.go
+++ b/controllers/vpcendpoint/helpers.go
@@ -460,6 +460,7 @@ func (r *VpcEndpointReconciler) ensureVpcEndpointSubnets(ctx context.Context, vp
 		if err != nil {
 			return err
 		}
+		r.log.V(1).Info("Discovered private subnet(s):", "subnets", privateSubnets)
 
 		// When auto-discovering the cluster's private subnet ids, only subnets supported by the VPC Endpoint
 		// Service should be attached
@@ -478,6 +479,7 @@ func (r *VpcEndpointReconciler) ensureVpcEndpointSubnets(ctx context.Context, vp
 			}
 		}
 
+		r.log.V(1).Info("Private subnet(s) in availability zones supported by the VPC Endpoint Service:", "subnets", expectedSubnetIds, "serviceName", resource.Spec.ServiceName)
 		subnetsToAdd, subnetsToRemove = util.StringSliceTwoWayDiff(vpce.SubnetIds, expectedSubnetIds)
 	} else {
 		// When subnet ids are specified, use exactly those subnets


### PR DESCRIPTION
For [OSD-15012](https://issues.redhat.com//browse/OSD-15012) when we autodiscover subnets, we need to filter away any subnets in availability zones that the VPC Endpoint Service doesn't support, which is crucial in cases like `us-east-1`, where there are 6 availability zones.

### AWS RBAC
* This feature requires a new permission: `ec2:DescribeVpcEndpointServices`
* While adding that in `pkg/aws_client/client.go` I noticed we are not using `ec2:DeleteTags` nor `ec2:DescribeTags`