### PR TITLE
Remove unused ec2:DescribeVpcs permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ AVO currently assumes it is running on an AWS OpenShift cluster, specifically:
             "ec2:AuthorizeSecurityGroupIngress",
             "ec2:AuthorizeSecurityGroupEgress",
             "ec2:DescribeSecurityGroupRules",
-            "ec2:DescribeVpcs",
             "ec2:CreateVpcEndpoint",
             "ec2:DeleteVpcEndpoints",
             "ec2:DescribeVpcEndpoints",

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -71,7 +71,6 @@ objects:
             - ec2:AuthorizeSecurityGroupIngress
             - ec2:AuthorizeSecurityGroupEgress
             - ec2:DescribeSecurityGroupRules
-            - ec2:DescribeVpcs
             - ec2:CreateVpcEndpoint
             - ec2:DeleteVpcEndpoints
             - ec2:DescribeVpcEndpoints
@@ -192,7 +191,6 @@ objects:
               - ec2:AuthorizeSecurityGroupIngress
               - ec2:AuthorizeSecurityGroupEgress
               - ec2:DescribeSecurityGroupRules
-              - ec2:DescribeVpcs
               - ec2:CreateVpcEndpoint
               - ec2:DeleteVpcEndpoints
               - ec2:DescribeVpcEndpoints
@@ -313,7 +311,6 @@ objects:
               - ec2:AuthorizeSecurityGroupIngress
               - ec2:AuthorizeSecurityGroupEgress
               - ec2:DescribeSecurityGroupRules
-              - ec2:DescribeVpcs
               - ec2:CreateVpcEndpoint
               - ec2:DeleteVpcEndpoints
               - ec2:DescribeVpcEndpoints


### PR DESCRIPTION
If you search the codebase it's not present anywhere, it must be a relic of the past.