### PR TITLE
Consolidate management and service cluster SSS

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -20,6 +20,9 @@ parameters:
   required: true
 
 objects:
+###############
+# FedRAMP SSS #
+###############
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -62,7 +65,7 @@ objects:
           - effect: Allow
             resource: '*'
             action:
-            # VPCEndpoint
+            # VPCEndpoint Controller
             - ec2:CreateTags
             - ec2:DescribeSubnets
             - ec2:CreateSecurityGroup
@@ -84,7 +87,7 @@ objects:
             - route53:CreateHostedZone
             - route53:DeleteHostedZone
             - route53:ChangeTagsForResource
-            # VPCEndpointAcceptance
+            # VPCEndpointAcceptance Controller
             - sts:AssumeRole
             - ec2:DescribeVpcEndpointConnections
             - ec2:AcceptVpcEndpointConnections
@@ -137,6 +140,9 @@ objects:
         source: ${REPO_NAME}-registry
         sourceNamespace: openshift-${REPO_NAME}
 
+##################
+# HyperShift SSS #
+##################
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -148,13 +154,15 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: aws-vpce-operator-svc-sss
+    name: aws-vpce-operator-hypershift-sss
   spec:
     clusterDeploymentSelector:
       matchExpressions:
         - key: ext-hypershift.openshift.io/cluster-type
           operator: In
-          values: ["service-cluster"]
+          values:
+            - "management-cluster"
+            - "service-cluster"
         - key: api.openshift.com/fedramp
           operator: NotIn
           values: ["true"]
@@ -182,7 +190,7 @@ objects:
           - effect: Allow
             resource: '*'
             action:
-              # VPCEndpoint
+              # VPCEndpoint Controller
               - ec2:CreateTags
               - ec2:DescribeSubnets
               - ec2:CreateSecurityGroup
@@ -204,127 +212,7 @@ objects:
               - route53:CreateHostedZone
               - route53:DeleteHostedZone
               - route53:ChangeTagsForResource
-              # VPCEndpointAcceptance
-              - sts:AssumeRole
-              - ec2:DescribeVpcEndpointConnections
-              - ec2:AcceptVpcEndpointConnections
-    - apiVersion: operators.coreos.com/v1alpha1
-      kind: CatalogSource
-      metadata:
-        labels:
-          opsrc-datastore: 'true'
-          opsrc-provider: redhat
-        name: ${REPO_NAME}-registry
-        namespace: openshift-${REPO_NAME}
-      spec:
-        image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
-        affinity:
-          nodeAffinity:
-            preferredDuringSchedulingIgnoredDuringExecution:
-            - preference:
-                matchExpressions:
-                - key: node-role.kubernetes.io/infra
-                  operator: Exists
-              weight: 1
-        tolerations:
-        - operator: Exists
-          key: node-role.kubernetes.io/infra
-          effect: NoSchedule
-        displayName: ${REPO_NAME}
-        icon:
-          base64data: ''
-          mediatype: ''
-        publisher: Red Hat
-        sourceType: grpc
-    - apiVersion: operators.coreos.com/v1
-      kind: OperatorGroup
-      metadata:
-        name: ${REPO_NAME}
-        namespace: openshift-${REPO_NAME}
-        annotations:
-          olm.operatorframework.io/exclude-global-namespace-resolution: 'true'
-      spec:
-        targetNamespaces:
-        - openshift-${REPO_NAME}
-    - apiVersion: operators.coreos.com/v1alpha1
-      kind: Subscription
-      metadata:
-        name: ${REPO_NAME}
-        namespace: openshift-${REPO_NAME}
-      spec:
-        channel: ${CHANNEL}
-        name: ${REPO_NAME}
-        source: ${REPO_NAME}-registry
-        sourceNamespace: openshift-${REPO_NAME}
-
-- apiVersion: hive.openshift.io/v1
-  kind: SelectorSyncSet
-  metadata:
-    annotations:
-      component-display-name: ${DISPLAY_NAME}
-      component-name: ${REPO_NAME}
-      telemeter-query: csv_succeeded{_id="$CLUSTER_ID",name=~"${REPO_NAME}.*",exported_namespace=~"openshift-.*",namespace="openshift-operator-lifecycle-manager"} == 1
-    labels:
-      managed.openshift.io/gitHash: ${IMAGE_TAG}
-      managed.openshift.io/gitRepoName: ${REPO_NAME}
-      managed.openshift.io/osd: 'true'
-    name: aws-vpce-operator-mgmt-sss
-  spec:
-    clusterDeploymentSelector:
-      matchExpressions:
-        - key: ext-hypershift.openshift.io/cluster-type
-          operator: In
-          values: ["management-cluster"]
-        - key: api.openshift.com/fedramp
-          operator: NotIn
-          values: ["true"]
-    resourceApplyMode: Sync
-    resources:
-    - kind: Namespace
-      apiVersion: v1
-      metadata:
-        name: openshift-aws-vpce-operator
-        labels:
-          openshift.io/cluster-monitoring: 'true'
-    - apiVersion: cloudcredential.openshift.io/v1
-      kind: CredentialsRequest
-      metadata:
-        name: avo-aws-iam-user-creds
-        namespace: openshift-${REPO_NAME}
-      spec:
-        secretRef:
-          name: avo-aws-iam-user-creds
-          namespace: openshift-${REPO_NAME}
-        providerSpec:
-          apiVersion: cloudcredential.openshift.io/v1
-          kind: AWSProviderSpec
-          statementEntries:
-          - effect: Allow
-            resource: '*'
-            action:
-              # VPCEndpoint
-              - ec2:CreateTags
-              - ec2:DescribeSubnets
-              - ec2:CreateSecurityGroup
-              - ec2:DeleteSecurityGroup
-              - ec2:DescribeSecurityGroups
-              - ec2:AuthorizeSecurityGroupIngress
-              - ec2:AuthorizeSecurityGroupEgress
-              - ec2:DescribeSecurityGroupRules
-              - ec2:CreateVpcEndpoint
-              - ec2:DeleteVpcEndpoints
-              - ec2:DescribeVpcEndpoints
-              - ec2:ModifyVpcEndpoint
-              - ec2:DescribeVpcEndpointServices
-              - route53:ChangeResourceRecordSets
-              - route53:ListHostedZonesByVPC
-              - route53:ListResourceRecordSets
-              - route53:ListTagsForResource
-              - route53:GetHostedZone
-              - route53:CreateHostedZone
-              - route53:DeleteHostedZone
-              - route53:ChangeTagsForResource
-              # VPCEndpointAcceptance
+              # VPCEndpointAcceptance Controller
               - sts:AssumeRole
               - ec2:DescribeVpcEndpointConnections
               - ec2:AcceptVpcEndpointConnections


### PR DESCRIPTION
We were maintaining essentially a duplicate SSS for service and management clusters.

Concerns:
* I don't have 100% confidence on what the behavior of this PR will be in practice, especially around whether I will need to manually delete the old `aws-vpce-operator-mgmt-sss` and `aws-vpce-operator-svc-sss` resources from Hive/whether it will initially clash with the new `aws-vpce-operator-hypershift-sss` resource. However, I think this is a safe learning opportunity since it'll be stage.