### PR TITLE
[OSD-15012] Use controller-runtime logging functionality over hand-rolling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ boilerplate-update:
 
 .PHONY: run
 run:
-	go run ./main.go
+	go run ./main.go $(ARGS)
 
 ifndef ignore-not-found
   ignore-not-found = false
@@ -37,4 +37,4 @@ osde2e:
 
 .PHONY: harness-build-push
 harness-build-push:
-	@${DIR}/osde2e/harness-build-push.sh 
+	@${DIR}/osde2e/harness-build-push.sh

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -22,29 +22,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/go-logr/logr"
-	"github.com/go-logr/zapr"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 	"golang.org/x/time/rate"
 	"k8s.io/client-go/util/workqueue"
 )
-
-// DefaultAVOLogger returns a zap.Logger using RFC3339 timestamps for the vpcendpoint controller
-func DefaultAVOLogger(controllerName string) (logr.Logger, error) {
-	config := zap.NewProductionConfig()
-	config.EncoderConfig.EncodeTime = zapcore.TimeEncoderOfLayout(time.RFC3339)
-	// TODO: Make this configurable
-	// config.Level = zap.NewAtomicLevelAt(zapcore.DebugLevel)
-
-	zapBase, err := config.Build()
-	if err != nil {
-		return logr.Logger{}, err
-	}
-
-	logger := zapr.NewLogger(zapBase)
-	return logger.WithName(controllerName), nil
-}
 
 // DefaultAVORateLimiter returns a rate limiter that reconciles more slowly than the default.
 // The default is 5ms --> 1000s, but resources are created much more slowly in AWS than in

--- a/controllers/vpcendpoint/vpcendpoint_controller.go
+++ b/controllers/vpcendpoint/vpcendpoint_controller.go
@@ -19,7 +19,6 @@ package vpcendpoint
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/aws/smithy-go"
@@ -35,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // VpcEndpointReconciler reconciles a VpcEndpoint object
@@ -73,13 +73,7 @@ type clusterInfo struct {
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 func (r *VpcEndpointReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	reqLogger, err := util.DefaultAVOLogger(ControllerName)
-	if err != nil {
-		// Shouldn't happen, but if it does, we can't log
-		return ctrl.Result{}, fmt.Errorf("unable to log: %w", err)
-	}
-
-	r.log = reqLogger.WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name)
+	r.log = ctrllog.FromContext(ctx).WithName("controller").WithName(ControllerName)
 
 	vpce := new(avov1alpha2.VpcEndpoint)
 	if err := r.Get(ctx, req.NamespacedName, vpce); err != nil {

--- a/controllers/vpcendpointacceptance/vpcendpointacceptance_controller.go
+++ b/controllers/vpcendpointacceptance/vpcendpointacceptance_controller.go
@@ -18,7 +18,6 @@ package vpcendpointacceptance
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -36,6 +35,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // VpcEndpointAcceptanceReconciler reconciles a VpcEndpointAcceptance object
@@ -53,13 +53,7 @@ type VpcEndpointAcceptanceReconciler struct {
 //+kubebuilder:rbac:groups=aws.managed.openshift.io,resources=account,verbs=get;list
 
 func (r *VpcEndpointAcceptanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	reqLogger, err := util.DefaultAVOLogger(controllerName)
-	if err != nil {
-		// Shouldn't happen, but if it does, we can't log
-		return ctrl.Result{}, fmt.Errorf("unable to log: %w", err)
-	}
-
-	r.log = reqLogger.WithValues("Request.Name", req.Name)
+	r.log = ctrllog.FromContext(ctx).WithName("controller").WithName(controllerName)
 
 	vpceAcceptance := new(avov1alpha1.VpcEndpointAcceptance)
 	if err := r.Get(ctx, req.NamespacedName, vpceAcceptance); err != nil {

--- a/dev/README.md
+++ b/dev/README.md
@@ -109,6 +109,9 @@ run locally (i.e. with `go run .`) and depends on local K8s and AWS credentials 
     ```bash
     # We currently have no webhooks anyway, so ENABLE_WEBHOOKS=false is optional
     make run ENABLE_WEBHOOKS=false
+   
+    # Running with debug logs enabled
+    make run ARGS="--zap-log-level=debug" ENABLE_WEBHOOKS=false
     ```
 
 ## Running in a ROSA STS cluster

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.18.2
 	github.com/aws/smithy-go v1.13.5
 	github.com/go-logr/logr v1.2.3
-	github.com/go-logr/zapr v1.2.3
 	github.com/onsi/ginkgo/v2 v2.8.0
 	github.com/onsi/gomega v1.26.0
 	github.com/openshift/api v0.0.0-20220414050251-a83e6f8f1d50
@@ -52,6 +51,7 @@ require (
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
+	github.com/go-logr/zapr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
 	github.com/go-openapi/swag v0.19.14 // indirect


### PR DESCRIPTION
* Adjusting `make run` to match upstream Operator-SDK https://github.com/operator-framework/operator-sdk/blob/master/website/content/en/docs/building-operators/golang/references/logging.md#setting-flags-when-running-locally
* This change mainly focuses on addressing a long-standing TODO where debug logs were effectively impossible to print. This is now possible with `make run ARGS="--zap-log-level=debug"` as well as by applying these flags in the deployment YAML (as well as any of the default flags described in https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/log/zap#Options.BindFlags)
* We no longer need to manually add `Request.Name` and `Request.Namespace` to the logger, they're there by default!

This allows us to get rid of our hand-rolled default logger.

Logs now look like this by default:

```json
{"level":"info","ts":"2023-02-06T20:20:19-05:00","logger":"controller-runtime.metrics","msg":"Metrics server is starting to listen","addr":":8080"}
{"level":"info","ts":"2023-02-06T20:20:19-05:00","logger":"setup","msg":"starting controller","controller":"VpcEndpoint"}
{"level":"info","ts":"2023-02-06T20:20:19-05:00","logger":"setup","msg":"starting manager"}
{"level":"info","ts":"2023-02-06T20:20:19-05:00","msg":"Starting server","path":"/metrics","kind":"metrics","addr":"[::]:8080"}
{"level":"info","ts":"2023-02-06T20:20:19-05:00","msg":"Starting server","kind":"health probe","addr":"[::]:8081"}
{"level":"info","ts":"2023-02-06T20:20:19-05:00","msg":"Starting EventSource","controller":"vpcendpoint","controllerGroup":"avo.openshift.io","controllerKind":"VpcEndpoint","source":"kind source: *v1alpha2.VpcEndpoint"}
{"level":"info","ts":"2023-02-06T20:20:19-05:00","msg":"Starting EventSource","controller":"vpcendpoint","controllerGroup":"avo.openshift.io","controllerKind":"VpcEndpoint","source":"kind source: *v1.Service"}
{"level":"info","ts":"2023-02-06T20:20:19-05:00","msg":"Starting Controller","controller":"vpcendpoint","controllerGroup":"avo.openshift.io","controllerKind":"VpcEndpoint"}
{"level":"info","ts":"2023-02-06T20:20:19-05:00","msg":"Starting workers","controller":"vpcendpoint","controllerGroup":"avo.openshift.io","controllerKind":"VpcEndpoint","worker count":1}
{"level":"error","ts":"2023-02-06T20:20:20-05:00","msg":"Reconciler error","controller":"vpcendpoint","controllerGroup":"avo.openshift.io","controllerKind":"VpcEndpoint","VpcEndpoint":{"name":"demo","namespace":"openshift-aws-vpce-operator"},"namespace":"openshift-aws-vpce-operator","name":"demo","reconcileID":"c2e59e31-1c0e-4000-86da-96cfc985629c","error":"failed to get infrastructure cluster: no matches for kind \"Infrastructure\" in version \"config.openshift.io/v1\""}
{"level":"error","ts":"2023-02-06T20:20:22-05:00","msg":"Reconciler error","controller":"vpcendpoint","controllerGroup":"avo.openshift.io","controllerKind":"VpcEndpoint","VpcEndpoint":{"name":"demo","namespace":"openshift-aws-vpce-operator"},"namespace":"openshift-aws-vpce-operator","name":"demo","reconcileID":"9efe1caa-e989-4f72-ac36-f287d727a80b","error":"failed to get infrastructure cluster: no matches for kind \"Infrastructure\" in version \"config.openshift.io/v1\""}
{"level":"error","ts":"2023-02-06T20:20:36-05:00","msg":"Reconciler error","controller":"vpcendpoint","controllerGroup":"avo.openshift.io","controllerKind":"VpcEndpoint","VpcEndpoint":{"name":"demo","namespace":"openshift-aws-vpce-operator"},"namespace":"openshift-aws-vpce-operator","name":"demo","reconcileID":"60f7009b-1417-478f-89ac-a6f0e593d84e","error":"failed to get infrastructure cluster: no matches for kind \"Infrastructure\" in version \"config.openshift.io/v1\""}
{"level":"info","ts":"2023-02-06T20:20:51-05:00","msg":"Stopping and waiting for non leader election runnables"}
{"level":"info","ts":"2023-02-06T20:20:51-05:00","msg":"Stopping and waiting for leader election runnables"}
{"level":"info","ts":"2023-02-06T20:20:51-05:00","msg":"Shutdown signal received, waiting for all workers to finish","controller":"vpcendpoint","controllerGroup":"avo.openshift.io","controllerKind":"VpcEndpoint"}
{"level":"info","ts":"2023-02-06T20:20:51-05:00","msg":"All workers finished","controller":"vpcendpoint","controllerGroup":"avo.openshift.io","controllerKind":"VpcEndpoint"}
{"level":"info","ts":"2023-02-06T20:20:51-05:00","msg":"Stopping and waiting for caches"}
{"level":"info","ts":"2023-02-06T20:20:51-05:00","msg":"Stopping and waiting for webhooks"}
{"level":"info","ts":"2023-02-06T20:20:51-05:00","msg":"Wait completed, proceeding to shutdown the manager"}
```

