### PR TITLE
Store VPC ID in status so that it does not need to be continually detected

### DIFF
--- a/api/v1alpha2/vpcendpoint_types.go
+++ b/api/v1alpha2/vpcendpoint_types.go
@@ -172,6 +172,10 @@ type VpcEndpointStatus struct {
 	// +kubebuilder:validation:Optional
 	SecurityGroupId string `json:"securityGroupId,omitempty"`
 
+	// The AWS ID of the VPC to create resources in
+	// +kubebuilder:validation:Optional
+	VPCId string `json:"vpcId,omitempty"`
+
 	// The AWS ID of the managed VPC Endpoint
 	// +kubebuilder:validation:Optional
 	VPCEndpointId string `json:"vpcEndpointId,omitempty"`

--- a/controllers/vpcendpoint/validation.go
+++ b/controllers/vpcendpoint/validation.go
@@ -255,7 +255,7 @@ func (r *VpcEndpointReconciler) validateR53PrivateHostedZone(ctx context.Context
 		r.log.V(1).Info("Found domain name:", "domainName", domainName)
 
 		r.log.V(1).Info("Searching for Route53 Hosted Zone by domain name", "domainName", domainName)
-		hz, err := r.awsClient.GetDefaultPrivateHostedZoneId(ctx, domainName, r.clusterInfo.vpcId, r.clusterInfo.region)
+		hz, err := r.awsClient.GetDefaultPrivateHostedZoneId(ctx, domainName, resource.Status.VPCId, r.clusterInfo.region)
 		if err != nil {
 			return err
 		}

--- a/controllers/vpcendpoint/vpcendpoint_controller.go
+++ b/controllers/vpcendpoint/vpcendpoint_controller.go
@@ -59,8 +59,6 @@ type clusterInfo struct {
 	infraName string
 	// region is the AWS region for the cluster
 	region string
-	// vpcId is the AWS VPC ID the cluster resides in
-	vpcId string
 }
 
 //+kubebuilder:rbac:groups=avo.openshift.io,resources=vpcendpoints,verbs=get;list;watch;create;update;patch;delete

--- a/deploy/crds/avo.openshift.io_vpcendpoints.yaml
+++ b/deploy/crds/avo.openshift.io_vpcendpoints.yaml
@@ -508,6 +508,9 @@ spec:
               vpcEndpointId:
                 description: The AWS ID of the managed VPC Endpoint
                 type: string
+              vpcId:
+                description: The AWS ID of the VPC to create resources in
+                type: string
             type: object
         type: object
     served: true


### PR DESCRIPTION
[OSD-15012](https://issues.redhat.com//browse/OSD-15012)

This PR takes `vpcId` out of the `clusterInfo` struct and places it as a status field on the VPCEndpoint CR. This is a bit of a no-op in the other scenarios, but is a must when using VPC load-balancing since the least-used VPC may continuously change across reconcile loops. By storing this on the VPCEndpoint CR, this will allow it to remain constant after being set the first time.
