### PR TITLE
Add back ec2:DescribeVpcs, which is needed by route53:ListHostedZonesByVPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ AVO currently assumes it is running on an AWS OpenShift cluster, specifically:
             "ec2:CreateVpcEndpoint",
             "ec2:DeleteVpcEndpoints",
             "ec2:DescribeVpcEndpoints",
+            "ec2:DescribeVpcs",
             "ec2:ModifyVpcEndpoint",
             "ec2:DescribeVpcEndpointServices",
             "route53:ChangeResourceRecordSets",

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -77,6 +77,7 @@ objects:
             - ec2:CreateVpcEndpoint
             - ec2:DeleteVpcEndpoints
             - ec2:DescribeVpcEndpoints
+            - ec2:DescribeVpcs
             - ec2:ModifyVpcEndpoint
             - ec2:DescribeVpcEndpointServices
             - route53:ChangeResourceRecordSets
@@ -202,6 +203,7 @@ objects:
               - ec2:CreateVpcEndpoint
               - ec2:DeleteVpcEndpoints
               - ec2:DescribeVpcEndpoints
+              - ec2:DescribeVpcs
               - ec2:ModifyVpcEndpoint
               - ec2:DescribeVpcEndpointServices
               - route53:ChangeResourceRecordSets


### PR DESCRIPTION
[OSD-15112](https://issues.redhat.com//browse/OSD-15112)

I made a mistake and removed this in #111 - even though there is no `ec2:DescribeVpcs` in our code base, `route53:ListHostedZonesByVPC` makes this call under the hood.

```json
{"level":"error","ts":"2023-02-07T18:57:52Z","msg":"Reconciler error","controller":"vpcendpoint","controllerGroup":"avo.openshift.io","controllerKind":"VpcEndpoint","VpcEndpoint":{"name":"avo-mc-to-sc","namespace":"openshift-aws-vpce-operator"},"namespace":"openshift-aws-vpce-operator","name":"avo-mc-to-sc","reconcileID":"57117304-e039-4467-8ae1-a2b419fdce26","error":"operation error Route 53: ListHostedZonesByVPC, https response error StatusCode: 403, RequestID: 95ce100a-923d-4874-bda6-bdba9cb84550, api error AccessDenied: Failed to verify the given VPC by calling ec2:DescribeVpcs: You are not authorized to perform this operation. (Service: AmazonEC2; Status Code: 403; Error Code: UnauthorizedOperation; Request ID: 4670666b-9fe2-495a-8e52-a98fb24c27eb; Proxy: null)"}
```