### PR TITLE
Ignore empty tag keys as they are invalid input for our purposes

### DIFF
--- a/pkg/aws_client/subnet.go
+++ b/pkg/aws_client/subnet.go
@@ -88,11 +88,15 @@ func (c *AWSClient) AutodiscoverPrivateSubnets(ctx context.Context, clusterTag s
 
 // DescribeSubnetsByTagKey returns a list of subnets that have all the specified tag key(s).
 func (c *AWSClient) DescribeSubnetsByTagKey(ctx context.Context, tagKey ...string) (*ec2.DescribeSubnetsOutput, error) {
-	filters := make([]types.Filter, len(tagKey))
-	for i := range tagKey {
-		filters[i] = types.Filter{
-			Name:   aws.String("tag-key"),
-			Values: []string{tagKey[i]},
+	filters := []types.Filter{}
+	for _, t := range tagKey {
+		// If a tag-key is empty, don't filter by it as it will exclude all subnets i.e. treat it as bad input.
+		if t != "" {
+			filters = append(filters, types.Filter{
+				Name: aws.String("tag-key"),
+				// Values are OR-ed
+				Values: []string{t},
+			})
 		}
 	}
 


### PR DESCRIPTION
Small edge-case noticed when validating OSD-15012, but AVO can get stuck if it's searching for subnets with an empty tag-key:

```json
{"level":"error","ts":"2023-02-08T19:58:55Z","msg":"Reconciler error","controller":"vpcendpoint","controllerGroup":"avo.openshift.io","controllerKind":"VpcEndpoint","VpcEndpoint":{"name":"avo-privatelink-to-mc","namespace":"openshift-aws-vpce-operator"},"namespace":"openshift-aws-vpce-operator","name":"avo-privatelink-to-mc","reconcileID":"75fd7895-325d-4fb2-a8b2-ff25473cc834","error":"failed to reconcile VPC Endpoint subnets: failed to find subnets with tag key: "}
```