### PR TITLE
AVO Progressive Delivery - 2

### DIFF
--- a/hack/tests/avo-acceptance-test.yaml
+++ b/hack/tests/avo-acceptance-test.yaml
@@ -37,7 +37,7 @@ parameters:
 - name: IMAGE
   value: openshift/origin-tools
 - name: IMAGE_TAG
-  value: ''
+  value: 'latest'
   required: true
 - name: SERVICE_ACCOUNT
   value: "saas-avo-test"


### PR DESCRIPTION
Force the origin-tools to use the latest tag. 
App-interface is pulling the sha from this repo instead of origin-tools'