### PR TITLE
removes namespace from direct deployment

### DIFF
--- a/hack/olm-registry/olm-artifacts-template-fedramp.yaml
+++ b/hack/olm-registry/olm-artifacts-template-fedramp.yaml
@@ -20,12 +20,6 @@ parameters:
   required: true
 
 objects:
-- apiVersion: v1
-  kind: Namespace
-  metadata:
-    name: openshift-aws-vpce-operator
-    labels:
-      openshift.io/cluster-monitoring: 'true'
 - apiVersion: cloudcredential.openshift.io/v1
   kind: CredentialsRequest
   metadata:


### PR DESCRIPTION
This template will be used for applying directly to Hive clusters using an App Interface namespace file. Since the Namespace file in App Interface is ensuring the namespace, having the namespace defined here is extra and AppSRE would prefer the namespace not be managed in both places.

The namespace in the SSS for all other clusters is kept since this is deployed to non-hives as well, and the namespace file does not ensure the namespace for anything but the hive cluster it targets.