### PR TITLE
Add IP Range when no Source Security Group Available

### DIFF
--- a/controllers/vpcendpoint/helpers.go
+++ b/controllers/vpcendpoint/helpers.go
@@ -321,6 +321,12 @@ func (r *VpcEndpointReconciler) generateMissingSecurityGroupRules(ctx context.Co
 				IpProtocol: aws.String(resource.Spec.SecurityGroup.IngressRules[i].Protocol),
 				FromPort:   aws.Int32(resource.Spec.SecurityGroup.IngressRules[i].FromPort),
 				ToPort:     aws.Int32(resource.Spec.SecurityGroup.IngressRules[i].ToPort),
+				IpRanges: []ec2Types.IpRange{
+					{
+						// TODO: Make IP range configurable
+						CidrIp: aws.String("0.0.0.0/0"),
+					},
+				},
 			})
 		}
 	}
@@ -357,6 +363,12 @@ func (r *VpcEndpointReconciler) generateMissingSecurityGroupRules(ctx context.Co
 				IpProtocol: aws.String(resource.Spec.SecurityGroup.EgressRules[i].Protocol),
 				FromPort:   aws.Int32(resource.Spec.SecurityGroup.EgressRules[i].FromPort),
 				ToPort:     aws.Int32(resource.Spec.SecurityGroup.EgressRules[i].ToPort),
+				IpRanges: []ec2Types.IpRange{
+					{
+						// TODO: Make IP range configurable
+						CidrIp: aws.String("0.0.0.0/0"),
+					},
+				},
 			})
 		}
 	}

--- a/controllers/vpcendpoint/validation.go
+++ b/controllers/vpcendpoint/validation.go
@@ -109,6 +109,7 @@ func (r *VpcEndpointReconciler) validateSecurityGroup(ctx context.Context, resou
 
 	// Not idempotent
 	if _, err := r.awsClient.AuthorizeSecurityGroupRules(ctx, ingressInput, egressInput); err != nil {
+		r.log.V(0).Error(err, "failed to authorize security group rules")
 		return err
 	}
 


### PR DESCRIPTION
This adds the necessary IP ranges when there is no source SG. Also added better error messaging when adding rules fails.
[OSD-15465](https://issues.redhat.com/browse/OSD-15465)