### PR TITLE
OSD-15146: revert changes to fedramp sss template

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -37,23 +37,10 @@ objects:
     name: aws-vpce-operator
   spec:
     clusterDeploymentSelector:
-      matchExpressions:
-        - key: api.openshift.com/managed
-          operator: In
-          values:
-            - "true"
-        - key: api.openshift.com/fedramp
-          operator: In
-          values:
-            - "true"
-        - key: api.openshift.com/private-link
-          operator: In
-          values:
-            - "true"
-        - key: ext-managed.openshift.io/hive-shard
-          operator: NotIn
-          values:
-            - "true"
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        api.openshift.com/fedramp: 'true'
+        api.openshift.com/private-link: 'true'
     resourceApplyMode: Sync
     resources:
     - kind: Namespace


### PR DESCRIPTION
- Reverts changes to base OLM template made in [ae27bf0](https://github.com/openshift/aws-vpce-operator/commit/ae27bf0e9d8a5975e7fd283f82b26632834c852b) as it was realized promoting the template with hives removed would remove the operator from hive and delete the namespace which we absolutely dont want. 
- More details on why in bullet point 4 of [this comment](https://issues.redhat.com/browse/OSD-15146?focusedId=21859064&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-21859064), we will need to gradually change this SSS and promote to all regions to orphan things we don't want to manage on Hives using the base SSS template anymore. 
