### PR TITLE
Improve logging to help isolate a bug

### DIFF
--- a/controllers/vpcendpoint/helpers.go
+++ b/controllers/vpcendpoint/helpers.go
@@ -105,12 +105,13 @@ func (r *VpcEndpointReconciler) parseClusterInfo(ctx context.Context, vpce *avov
 				return fmt.Errorf("failed to select a VPC to place a VPC Endpoint in: %w", err)
 			}
 
+			r.log.V(1).Info("Found candidate VPCs by tag", "ids", ids)
 			v, err := r.awsClient.SelectVPCForVPCEndpoint(ctx, ids...)
 			if err != nil {
 				return fmt.Errorf("failed to select a VPC to place a VPC Endpoint in: %w", err)
 			}
 			vpcId = v
-			r.log.V(1).Info("Selecting vpc id", "vpcId", vpcId)
+			r.log.V(1).Info("Selecting vpc id by tags", "vpcId", vpcId)
 		case len(vpce.Spec.Vpc.Ids) > 0:
 			v, err := r.awsClient.SelectVPCForVPCEndpoint(ctx, vpce.Spec.Vpc.Ids...)
 			if err != nil {

--- a/pkg/aws_client/vpc_endpoint.go
+++ b/pkg/aws_client/vpc_endpoint.go
@@ -70,6 +70,10 @@ func (c *AWSClient) SelectVPCForVPCEndpoint(ctx context.Context, ids ...string) 
 		minVpcId = vpcId
 	}
 
+	if minVpcId == "" {
+		return "", errors.New("unexpectedly did not select a VPC for the VPC Endpoint")
+	}
+
 	return minVpcId, nil
 }
 


### PR DESCRIPTION
```json
{"level":"debug","ts":"2023-03-20T21:24:01Z","logger":"controller.VpcEndpoint","msg":"Found infrastructure name:","controller":"vpcendpoint","controllerGroup":"avo.openshift.io","controllerKind":"VpcEndpoint","VpcEndpoint":{"name":"service-cluster-endpoint","namespace":"openshift-aws-vpce-operator"},"namespace":"openshift-aws-vpce-operator","name":"service-cluster-endpoint","reconcileID":"46cc7b16-4208-40d6-aa36-47e17d4187d2","name":"hs-sc-ge77jaj60-cw28q"}
{"level":"debug","ts":"2023-03-20T21:24:01Z","logger":"controller.VpcEndpoint","msg":"Found cluster tag:","controller":"vpcendpoint","controllerGroup":"avo.openshift.io","controllerKind":"VpcEndpoint","VpcEndpoint":{"name":"service-cluster-endpoint","namespace":"openshift-aws-vpce-operator"},"namespace":"openshift-aws-vpce-operator","name":"service-cluster-endpoint","reconcileID":"46cc7b16-4208-40d6-aa36-47e17d4187d2","clusterTag":"kubernetes.io/cluster/hs-sc-ge77jaj60-cw28q"}
{"level":"debug","ts":"2023-03-20T21:24:01Z","logger":"controller.VpcEndpoint","msg":"Parsed region from infrastructure","controller":"vpcendpoint","controllerGroup":"avo.openshift.io","controllerKind":"VpcEndpoint","VpcEndpoint":{"name":"service-cluster-endpoint","namespace":"openshift-aws-vpce-operator"},"namespace":"openshift-aws-vpce-operator","name":"service-cluster-endpoint","reconcileID":"46cc7b16-4208-40d6-aa36-47e17d4187d2","region":"us-east-1"}
{"level":"debug","ts":"2023-03-20T21:24:02Z","logger":"controller.VpcEndpoint","msg":"Selecting vpc id","controller":"vpcendpoint","controllerGroup":"avo.openshift.io","controllerKind":"VpcEndpoint","VpcEndpoint":{"name":"service-cluster-endpoint","namespace":"openshift-aws-vpce-operator"},"namespace":"openshift-aws-vpce-operator","name":"service-cluster-endpoint","reconcileID":"46cc7b16-4208-40d6-aa36-47e17d4187d2","vpcId":""}
```

For reasons that aren't entirely clear yet, somehow we are selecting a `vpcId: ""`, which shouldn't be possible. This PR just adds some additional logging to help isolate how this is happening.

[OSD-15465](https://issues.redhat.com//browse/OSD-15465)