### PR TITLE
Fix bug with load balancing when there are 0 VPC Endpoints

### DIFF
--- a/pkg/aws_client/client_test.go
+++ b/pkg/aws_client/client_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 type mockAvoEC2API struct {
+	describeVpcEndpointResp         *ec2.DescribeVpcEndpointsOutput
 	describeVpcEndpointServicesResp *ec2.DescribeVpcEndpointServicesOutput
 }
 
@@ -66,8 +67,7 @@ func (m mockAvoEC2API) DeleteVpcEndpoints(ctx context.Context, params *ec2.Delet
 }
 
 func (m mockAvoEC2API) DescribeVpcEndpoints(ctx context.Context, params *ec2.DescribeVpcEndpointsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVpcEndpointsOutput, error) {
-	//TODO implement me
-	panic("implement me")
+	return m.describeVpcEndpointResp, nil
 }
 
 func (m mockAvoEC2API) ModifyVpcEndpoint(ctx context.Context, params *ec2.ModifyVpcEndpointInput, optFns ...func(*ec2.Options)) (*ec2.ModifyVpcEndpointOutput, error) {

--- a/pkg/aws_client/vpc_endpoint.go
+++ b/pkg/aws_client/vpc_endpoint.go
@@ -47,9 +47,12 @@ func (c *AWSClient) SelectVPCForVPCEndpoint(ctx context.Context, ids ...string) 
 		},
 	}
 
-	minVpcId := ""
+	minVpcId := ids[0]
 	minVpceConsumed := math.MaxInt
 	vpcePerVpc := map[string]int{}
+	for _, id := range ids {
+		vpcePerVpc[id] = 0
+	}
 
 	paginator := ec2.NewDescribeVpcEndpointsPaginator(c.ec2Client, input)
 	for paginator.HasMorePages() {


### PR DESCRIPTION
[OSD-15465](https://issues.redhat.com//browse/OSD-15465)

The bug where AVO would select a VPC of "" occurs when all provided VPC IDs have 0 VPC Endpoints in them. This is because the map `vpcePerVpc` was previously never initialized to set the initial count for all VPC's to 0 - so when no VPC Endpoints are found with a call to `DescribeVpcEndpoints`, the map was completely empty and `minVpcId` remained at its default value, empty string.

This PR fixes this by defaulting the initial count for all VPC's to 0, defaulting `minVpcId` to the first supplied VPC ID, and unit testing this.