### PR TITLE
Add ability to configure CidrIP of security group rules

### DIFF
--- a/api/v1alpha2/vpcendpoint_types.go
+++ b/api/v1alpha2/vpcendpoint_types.go
@@ -23,6 +23,12 @@ import (
 
 // SecurityGroupRule is based on required inputs for `aws authorize-security-group-ingress/egress`
 type SecurityGroupRule struct {
+	// +kubebuilder:validation:Format=cidr
+
+	// CidrIp is the IPv4 address range, in CIDR format, to allow.
+	// If not specified, the cluster's master and worker security group are allowed instead.
+	CidrIp string `json:"cidrIp,omitempty"`
+
 	// FromPort and ToPort are the start and end of the port range to allow.
 	// In the case of a single port, set both to the same value.
 	FromPort int32 `json:"fromPort,omitempty"`

--- a/deploy/crds/avo.openshift.io_vpcendpoints.yaml
+++ b/deploy/crds/avo.openshift.io_vpcendpoints.yaml
@@ -338,6 +338,12 @@ spec:
                       description: SecurityGroupRule is based on required inputs for
                         `aws authorize-security-group-ingress/egress`
                       properties:
+                        cidrIp:
+                          description: CidrIp is the IPv4 address range, in CIDR format,
+                            to allow. If not specified, the cluster's master and worker
+                            security group are allowed instead.
+                          format: cidr
+                          type: string
                         fromPort:
                           description: FromPort and ToPort are the start and end of
                             the port range to allow. In the case of a single port,
@@ -364,6 +370,12 @@ spec:
                       description: SecurityGroupRule is based on required inputs for
                         `aws authorize-security-group-ingress/egress`
                       properties:
+                        cidrIp:
+                          description: CidrIp is the IPv4 address range, in CIDR format,
+                            to allow. If not specified, the cluster's master and worker
+                            security group are allowed instead.
+                          format: cidr
+                          type: string
                         fromPort:
                           description: FromPort and ToPort are the start and end of
                             the port range to allow. In the case of a single port,


### PR DESCRIPTION
This adds .spec.securityGroup.*Rules.CidrIp so that the created security group rules can optionally allow a target IPv4 CIDR range instead of only being allowed for the cluster's own master and worker security groups. If a CIDR range is specified, it will take precendence and be used, while the cluster's own master and worker security groups act as a fallback default.

Basically adds flexibility to the hardcoded `0.0.0.0/0` that was added in #144 

[OSD-15465](https://issues.redhat.com//browse/OSD-15465)