### PR TITLE
Fix nil-pointer exception bug

### DIFF
--- a/controllers/vpcendpoint/helpers.go
+++ b/controllers/vpcendpoint/helpers.go
@@ -309,7 +309,7 @@ func (r *VpcEndpointReconciler) generateMissingSecurityGroupRules(ctx context.Co
 			for _, rule := range rulesResp.SecurityGroupRules {
 				if avoAndAwsSecurityGroupRuleCandidate(false, resource.Spec.SecurityGroup.IngressRules[i], rule) {
 					// If we find a rule with the correct protocol, fromPort, and toPort, check CidrIP
-					if resource.Spec.SecurityGroup.IngressRules[i].CidrIp == *rule.CidrIpv4 {
+					if rule.CidrIpv4 != nil && resource.Spec.SecurityGroup.IngressRules[i].CidrIp == *rule.CidrIpv4 {
 						create = false
 						break
 					}
@@ -364,7 +364,7 @@ func (r *VpcEndpointReconciler) generateMissingSecurityGroupRules(ctx context.Co
 			for _, rule := range rulesResp.SecurityGroupRules {
 				if avoAndAwsSecurityGroupRuleCandidate(true, resource.Spec.SecurityGroup.IngressRules[i], rule) {
 					// If we find a rule with the correct protocol, fromPort, and toPort, check CidrIP
-					if resource.Spec.SecurityGroup.IngressRules[i].CidrIp == *rule.CidrIpv4 {
+					if rule.CidrIpv4 != nil && resource.Spec.SecurityGroup.IngressRules[i].CidrIp == *rule.CidrIpv4 {
 						create = false
 						break
 					}


### PR DESCRIPTION
This happens when a security group rule does not have an allowed CidrIp:
```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x21ff0c2]

goroutine 361 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
	pkg/mod/sigs.k8s.io/controller-runtime@v0.13.0/pkg/internal/controller/controller.go:118 +0x1f4
panic({0x247b640, 0x3aa9270})
	/usr/lib/golang/src/runtime/panic.go:884 +0x212
github.com/openshift/aws-vpce-operator/controllers/vpcendpoint.(*VpcEndpointReconciler).generateMissingSecurityGroupRules(0xc0003004e0, {0x2b75318, 0xc0004fe3f0}, 0xc000510400, 0xc00053e000)
	/workdir/controllers/vpcendpoint/helpers.go:312 +0x2542
github.com/openshift/aws-vpce-operator/controllers/vpcendpoint.(*VpcEndpointReconciler).validateSecurityGroup(0xc0003004e0, {0x2b75318, 0xc0004fe3f0}, 0xc00053e000)
	/workdir/controllers/vpcendpoint/validation.go:111 +0xd3
github.com/openshift/aws-vpce-operator/controllers/vpcendpoint.(*VpcEndpointReconciler).validateResources(...)
	/workdir/controllers/vpcendpoint/validation.go:41
github.com/openshift/aws-vpce-operator/controllers/vpcendpoint.(*VpcEndpointReconciler).Reconcile(0xc0003004e0, {0x2b75318, 0xc0004fe3f0}, {{{0xc00034c580?, 0x10?}, {0xc00022cb70?, 0x40e067?}}})
	/workdir/controllers/vpcendpoint/vpcendpoint_controller.go:130 +0x793
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x2b75270?, {0x2b75318?, 0xc0004fe3f0?}, {{{0xc00034c580?, 0x2664520?}, {0xc00022cb70?, 0x404b54?}}})
	pkg/mod/sigs.k8s.io/controller-runtime@v0.13.0/pkg/internal/controller/controller.go:121 +0xc8
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc000212be0, {0x2b75270, 0xc000060e40}, {0x2528080?, 0xc0007a0060?})
	pkg/mod/sigs.k8s.io/controller-runtime@v0.13.0/pkg/internal/controller/controller.go:320 +0x33c
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000212be0, {0x2b75270, 0xc000060e40})
	pkg/mod/sigs.k8s.io/controller-runtime@v0.13.0/pkg/internal/controller/controller.go:273 +0x1d9
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
	pkg/mod/sigs.k8s.io/controller-runtime@v0.13.0/pkg/internal/controller/controller.go:234 +0x85
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
	pkg/mod/sigs.k8s.io/controller-runtime@v0.13.0/pkg/internal/controller/controller.go:230 +0x333
```