### PR TITLE
Fix logic error with finding the VPC ID with the minumum number of VPC Endpoints

### DIFF
--- a/pkg/aws_client/vpc_endpoint.go
+++ b/pkg/aws_client/vpc_endpoint.go
@@ -47,7 +47,7 @@ func (c *AWSClient) SelectVPCForVPCEndpoint(ctx context.Context, ids ...string) 
 		},
 	}
 
-	minVpcId := ids[0]
+	minVpcId := ""
 	minVpceConsumed := math.MaxInt
 	vpcePerVpc := map[string]int{}
 	for _, id := range ids {
@@ -69,8 +69,8 @@ func (c *AWSClient) SelectVPCForVPCEndpoint(ctx context.Context, ids ...string) 
 	for vpcId, vpceCount := range vpcePerVpc {
 		if vpceCount < minVpceConsumed {
 			minVpceConsumed = vpceCount
+			minVpcId = vpcId
 		}
-		minVpcId = vpcId
 	}
 
 	if minVpcId == "" {


### PR DESCRIPTION
The loop was always picking a new VPC ID even if it wasn't really a minimum...whoops. This explains the sporadic test failures, e.g. https://github.com/openshift/aws-vpce-operator/pull/153#issuecomment-1478159504