### PR TITLE
Handle edge cases when replacing v1alpha1 VpcEndpoints with v1alpha2

### DIFF
--- a/controllers/vpcendpoint/helpers.go
+++ b/controllers/vpcendpoint/helpers.go
@@ -740,6 +740,11 @@ func (r *VpcEndpointReconciler) generateRoute53Record(ctx context.Context, resou
 	}
 
 	if len(vpceResp.VpcEndpoints[0].DnsEntries) == 0 {
+		if !resource.ObjectMeta.DeletionTimestamp.IsZero() {
+			// When we're deleting the VPC Endpoint, handle the edge case where it doesn't have any subnets attached anymore
+			return nil, nil
+		}
+
 		return nil, fmt.Errorf("VPCEndpoint has no DNS entries")
 	}
 


### PR DESCRIPTION
[OSD-15146](https://issues.redhat.com//browse/OSD-15146)

While migrating from v1alpha1 to v1alpha2, it was noticed that AVO reconciles away all the subnets of the VPC Endpoint in AWS, then eventually fails when executing generateRoute53Record() as there are no subnets attached to the VPC Endpoint, so it does not have any DNS names.

This commit handles the edge case by allowing that function to return without error when the VpcEnpoint CR is deleting and adds additional safeguards to ensure .status.hostedZoneId is populated before attempting to delete Route53 Record Sets.