### PR TITLE
empty ginkgo assertion  for osde2e prow job

### DIFF
--- a/osde2e/aws_vpce_operator_tests.go
+++ b/osde2e/aws_vpce_operator_tests.go
@@ -1,7 +1,14 @@
 package osde2etests
 
-import "github.com/onsi/ginkgo/v2"
+import (
+	"context"
+
+	"github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
 
 var _ = ginkgo.Describe("aws-vpce-operator", func() {
-	//	 Add your tests
+	ginkgo.It("Placeholder avo test", func(ctx context.Context) {
+		Expect(true).NotTo(Equal(false))
+	})
 })


### PR DESCRIPTION
Currently [postsubmit e2e test prow job](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-openshift-aws-vpce-operator-main-stage-e2e-harness/1644050248361840640) times out and fails to return results since there are no tests in the test file. Added an empty test assertion to dry run the e2e harness.

[sdcicd-888](https://issues.redhat.com//browse/sdcicd-888)