### PR TITLE
OSD-15146: updates fedramp sss to upsert to allow for removal of hives later

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -41,7 +41,7 @@ objects:
         api.openshift.com/managed: 'true'
         api.openshift.com/fedramp: 'true'
         api.openshift.com/private-link: 'true'
-    resourceApplyMode: Sync
+    resourceApplyMode: Upsert
     resources:
     - kind: Namespace
       apiVersion: v1


### PR DESCRIPTION
This is the beginning of multiple steps to remove Hives from the SSS in FedRAMP so that they can be promoted separately since they have their own specific configuration and settings that will require testing in non-prod at times. We want to test hive changes in non-prod without having to promote to prod to get changes on Hive. The steps to remove hives will be as follows:
1. update the SSS to upsert and promote to all regions (This PR)
2. Update SSS to ignore Hives and promote to all regions (orphaning AVO objects on hives from SSS)
3. Change SSS back to sync and promote to all regions

Remaining work will be to add the new Hive saas files in FedRAMP for Prod once they are removed from SSS