### PR TITLE
OSD-15146: removes hives from fr SSS

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -37,10 +37,23 @@ objects:
     name: aws-vpce-operator
   spec:
     clusterDeploymentSelector:
-      matchLabels:
-        api.openshift.com/managed: 'true'
-        api.openshift.com/fedramp: 'true'
-        api.openshift.com/private-link: 'true'
+      matchExpressions:
+        - key: api.openshift.com/managed
+          operator: In
+          values:
+            - "true"
+        - key: api.openshift.com/fedramp
+          operator: In
+          values:
+            - "true"
+        - key: api.openshift.com/private-link
+          operator: In
+          values:
+            - "true"
+        - key: ext-managed.openshift.io/hive-shard
+          operator: NotIn
+          values:
+            - "true"
     resourceApplyMode: Upsert
     resources:
     - kind: Namespace


### PR DESCRIPTION
- Updates the olm template to remove hives now that Upsert mode is set, to prevent deletion of the operator from Hives
- Future hive promotions will be done using the [olm-artifacts-template-fedramp.yaml](https://github.com/openshift/aws-vpce-operator/blob/main/hack/olm-registry/olm-artifacts-template-fedramp.yaml) template file
- Once this is promoted to all FR clusters, resourceApplyMode will be changed back to Sync, and leave hives off completing the hive removal process