### PR TITLE
changes the olm template back to the desired sync version

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -54,7 +54,7 @@ objects:
           operator: NotIn
           values:
             - "true"
-    resourceApplyMode: Upsert
+    resourceApplyMode: Sync
     resources:
     - kind: Namespace
       apiVersion: v1


### PR DESCRIPTION
Now that AVO on Hives has been orphaned thanks to previous promotions, this template is no longer managing hives and changing back to `Sync` is safe which is the original desired setting. It was merely changed to prevent deletion of AVO from Hives during the saas migration process.

[Validation showing](https://issues.redhat.com/browse/OSD-15146?focusedId=22091021&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-22091021) AVO is no longer referenced in clustersyncs for Hive clusters nor updated from promotion, changing this to sync will not delete AVO from hives since they are no longer managed.

