### PR TITLE
Add K8s RBAC for reading hypershift awsendpointservices

### DIFF
--- a/controllers/vpcendpoint/vpcendpoint_controller.go
+++ b/controllers/vpcendpoint/vpcendpoint_controller.go
@@ -68,6 +68,7 @@ type clusterInfo struct {
 //+kubebuilder:rbac:groups=config.openshift.io,resources=dnses,verbs=get,list
 //+kubebuilder:rbac:groups=v1,resources=services,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=v1,resources=services/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=hypershift.openshift.io,resources=awsendpointservices,verbs=get;list
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 func (r *VpcEndpointReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/deploy/15_clusterrole.yaml
+++ b/deploy/15_clusterrole.yaml
@@ -4,6 +4,14 @@ metadata:
   name: aws-vpce-operator
 rules:
   - apiGroups:
+      - hypershift.openshift.io
+    resources:
+      - awsendpointservices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
     - config.openshift.io
     resources:
     - infrastructures


### PR DESCRIPTION
This was forgotten during the changes in #171 where the VpcEndpoint controller was re-tooled to read a VPC Endpoint Service name from a `hypershift.openshift.io` `awsendpointservice` CR