### PR TITLE
Prefer scheduling registry pod onto infra nodes

### DIFF
--- a/hack/olm-registry/olm-artifacts-template-fedramp.yaml
+++ b/hack/olm-registry/olm-artifacts-template-fedramp.yaml
@@ -71,6 +71,13 @@ objects:
     namespace: openshift-${REPO_NAME}
   spec:
     image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
+    grpcPodConfig:
+      nodeSelector:
+        node-role.kubernetes.io: infra
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          operator: Exists
     affinity:
       nodeAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -115,6 +115,13 @@ objects:
         namespace: openshift-${REPO_NAME}
       spec:
         image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
+        grpcPodConfig:
+          nodeSelector:
+            node-role.kubernetes.io: infra
+          tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/infra
+              operator: Exists
         affinity:
           nodeAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:
@@ -241,6 +248,13 @@ objects:
         namespace: openshift-${REPO_NAME}
       spec:
         image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
+        grpcPodConfig:
+          nodeSelector:
+            node-role.kubernetes.io: infra
+          tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/infra
+              operator: Exists
         affinity:
           nodeAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
This commit specifies .spec.grpcPodConfig.nodeSelector and .spec.grpdPodConfig.tolerations to schedule this operator's registry pod to infra nodes when possible.

[OSD-6629](https://issues.redhat.com//browse/OSD-6629)