### PR TITLE
Revert scheduling onto infra nodes

### DIFF
--- a/hack/olm-registry/olm-artifacts-template-fedramp.yaml
+++ b/hack/olm-registry/olm-artifacts-template-fedramp.yaml
@@ -71,13 +71,6 @@ objects:
     namespace: openshift-${REPO_NAME}
   spec:
     image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
-    grpcPodConfig:
-      nodeSelector:
-        node-role.kubernetes.io: infra
-      tolerations:
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/infra
-          operator: Exists
     affinity:
       nodeAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -115,13 +115,6 @@ objects:
         namespace: openshift-${REPO_NAME}
       spec:
         image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
-        grpcPodConfig:
-          nodeSelector:
-            node-role.kubernetes.io: infra
-          tolerations:
-            - effect: NoSchedule
-              key: node-role.kubernetes.io/infra
-              operator: Exists
         affinity:
           nodeAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
This functionality first existed in 4.11, however there are still supported clusters on 4.10.
https://docs.openshift.com/container-platform/4.11/rest_api/operatorhub_apis/catalogsource-operators-coreos-com-v1alpha1.html

OSD-6629