### PR TITLE
.metadata.namespace is the only supported fieldPath

### DIFF
--- a/api/v1alpha2/vpcendpoint_types.go
+++ b/api/v1alpha2/vpcendpoint_types.go
@@ -138,8 +138,8 @@ type DnsSelector struct {
 // HostedControlPlaneSelector represents a selector for a hypershift.openshift.io/v1beta1 HostedControlPlane
 // custom resource
 type HostedControlPlaneSelector struct {
-	// Path of the field containing the namespace of the hostedcontrolplane, typically ".metadata.name" to select the
-	// same namespace as the VpcEndpoint itself
+	// Path of the field containing the namespace of the hostedcontrolplane, typically ".metadata.namespace" to select
+	// the same namespace as the VpcEndpoint itself
 	NamespaceFieldRef *ObjectFieldSelector `json:"namespaceFieldRef,omitempty"`
 }
 

--- a/controllers/vpcendpoint/helpers.go
+++ b/controllers/vpcendpoint/helpers.go
@@ -736,12 +736,14 @@ func (r *VpcEndpointReconciler) findOrCreatePrivateHostedZone(ctx context.Contex
 					return err
 				}
 			case resource.Spec.CustomDns.Route53PrivateHostedZone.DomainNameRef.ValueFrom.HostedControlPlaneRef != nil:
-				switch {
-				case resource.Spec.CustomDns.Route53PrivateHostedZone.DomainNameRef.ValueFrom.HostedControlPlaneRef.NamespaceFieldRef.FieldPath == ".metadata.name":
+				switch resource.Spec.CustomDns.Route53PrivateHostedZone.DomainNameRef.ValueFrom.HostedControlPlaneRef.NamespaceFieldRef.FieldPath {
+				case ".metadata.namespace":
 					domainName, err = hostedcontrolplanes.GetPrivateHostedZoneDomainName(ctx, r.Client, resource.Namespace)
 					if err != nil {
 						return err
 					}
+				default:
+					return fmt.Errorf("unsupported fieldPath: %s", resource.Spec.CustomDns.Route53PrivateHostedZone.DomainNameRef.ValueFrom.HostedControlPlaneRef.NamespaceFieldRef.FieldPath)
 				}
 			}
 		}

--- a/deploy/crds/avo.openshift.io_vpcendpoints.yaml
+++ b/deploy/crds/avo.openshift.io_vpcendpoints.yaml
@@ -318,7 +318,7 @@ spec:
                                   namespaceFieldRef:
                                     description: Path of the field containing the
                                       namespace of the hostedcontrolplane, typically
-                                      ".metadata.name" to select the same namespace
+                                      ".metadata.namespace" to select the same namespace
                                       as the VpcEndpoint itself
                                     properties:
                                       fieldPath:

--- a/deploy/crds/avo.openshift.io_vpcendpointtemplates.yaml
+++ b/deploy/crds/avo.openshift.io_vpcendpointtemplates.yaml
@@ -180,7 +180,7 @@ spec:
                                           namespaceFieldRef:
                                             description: Path of the field containing
                                               the namespace of the hostedcontrolplane,
-                                              typically ".metadata.name" to select
+                                              typically ".metadata.namespace" to select
                                               the same namespace as the VpcEndpoint
                                               itself
                                             properties:


### PR DESCRIPTION
Enum validation was already put in place to only allow `.metadata.namespace` https://github.com/openshift/aws-vpce-operator/blob/main/api/v1alpha2/vpcendpoint_types.go#L149, however the documentation/backend code was incorrectly acting as if `.metadata.name` was the only allowed option.

This PR fixes the bug and also returns an error now if an unsupported option is supplied.

[OSD-15666](https://issues.redhat.com//browse/OSD-15666)