### PR TITLE
Fixing bugs that have become obvious since adding the VpcEndpointTemplate

### DIFF
--- a/controllers/vpcendpoint/helpers.go
+++ b/controllers/vpcendpoint/helpers.go
@@ -623,7 +623,15 @@ func (r *VpcEndpointReconciler) ensureVpcEndpointSubnets(ctx context.Context, vp
 		for _, subnet := range discoveredSubnets {
 			for _, az := range allowedAZs {
 				if *subnet.AvailabilityZone == az {
-					expectedSubnetIds = append(expectedSubnetIds, *subnet.SubnetId)
+					if resource.Status.VPCId != "" {
+						// If the VPCE's status contains a VPC id, only select subnets from that VPC
+						if *subnet.VpcId == resource.Status.VPCId {
+							expectedSubnetIds = append(expectedSubnetIds, *subnet.SubnetId)
+						}
+					} else {
+						// Otherwise, just filter if the subnet's AZ matches
+						expectedSubnetIds = append(expectedSubnetIds, *subnet.SubnetId)
+					}
 					break
 				}
 			}

--- a/controllers/vpcendpointtemplate/const.go
+++ b/controllers/vpcendpointtemplate/const.go
@@ -17,5 +17,6 @@ limitations under the License.
 package vpcendpointtemplate
 
 const (
+	finalizer      = "vpcendpointtemplate.avo.openshift.io/finalizer"
 	ControllerName = "VpcEndpointTemplate"
 )

--- a/controllers/vpcendpointtemplate/vpcendpointtemplate_controller.go
+++ b/controllers/vpcendpointtemplate/vpcendpointtemplate_controller.go
@@ -84,7 +84,7 @@ func (r *VpcEndpointTemplateReconciler) Reconcile(ctx context.Context, req ctrl.
 				return ctrl.Result{}, err
 			}
 
-		// Delete all VpcEndpoints matching the label selector on this VpcEndpointTemplate
+			// Delete all VpcEndpoints matching the label selector on this VpcEndpointTemplate
 			// DeleteAllOf does not act across namespaces
 			// https://github.com/kubernetes-sigs/controller-runtime/issues/1842
 			for i := range vpceList.Items {
@@ -126,7 +126,7 @@ func (r *VpcEndpointTemplateReconciler) ValidateVpcEndpointForHostedControlPlane
 
 	// We want one VpcEndpoint per namespace/HCP per vpcet
 	for _, hcp := range hcpList {
-		r.log.V(0).Info("Validating HostedControlPlane", "namespace", hcp.Namespace, "name", hcp.Name)
+		r.log.V(1).Info("Validating HostedControlPlane", "namespace", hcp.Namespace, "name", hcp.Name)
 
 		vpceList := new(avov1alpha2.VpcEndpointList)
 		if err := r.List(ctx, vpceList, &client.ListOptions{

--- a/pkg/aws_client/route53_hosted_zone.go
+++ b/pkg/aws_client/route53_hosted_zone.go
@@ -45,7 +45,8 @@ func (c *AWSClient) GetDefaultPrivateHostedZoneId(ctx context.Context, domainNam
 
 // GetHostedZone is a wrapper around Route53 GetHostedZone
 func (c *AWSClient) GetHostedZone(ctx context.Context, id string) (*route53.GetHostedZoneOutput, error) {
-	return c.route53Client.GetHostedZone(ctx, &route53.GetHostedZoneInput{Id: aws.String(id)})
+	fullId := fmt.Sprintf("/hostedzone/%s", id)
+	return c.route53Client.GetHostedZone(ctx, &route53.GetHostedZoneInput{Id: aws.String(fullId)})
 }
 
 // ListHostedZonesByVPC is a wrapper around route53:ListHostedZonesByVPC

--- a/pkg/hostedcontrolplanes/hostedcontrolplanes_test.go
+++ b/pkg/hostedcontrolplanes/hostedcontrolplanes_test.go
@@ -42,16 +42,13 @@ func TestGetPrivateHostedZoneDomainName(t *testing.T) {
 					Namespace: "example",
 				},
 				Spec: hyperv1beta1.HostedControlPlaneSpec{
-					Platform: hyperv1beta1.PlatformSpec{
-						AWS: &hyperv1beta1.AWSPlatformSpec{
-							ServiceEndpoints: []hyperv1beta1.AWSServiceEndpoint{
-								{
-									Name: string(hyperv1beta1.OAuthServer),
-									URL:  "oauth.example.com",
-								},
-								{
-									Name: string(hyperv1beta1.APIServer),
-									URL:  "example.com",
+					Services: []hyperv1beta1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1beta1.APIServer,
+							ServicePublishingStrategy: hyperv1beta1.ServicePublishingStrategy{
+								Type: hyperv1beta1.Route,
+								Route: &hyperv1beta1.RoutePublishingStrategy{
+									Hostname: "example.com",
 								},
 							},
 						},
@@ -70,13 +67,11 @@ func TestGetPrivateHostedZoneDomainName(t *testing.T) {
 					Namespace: "example",
 				},
 				Spec: hyperv1beta1.HostedControlPlaneSpec{
-					Platform: hyperv1beta1.PlatformSpec{
-						AWS: &hyperv1beta1.AWSPlatformSpec{
-							ServiceEndpoints: []hyperv1beta1.AWSServiceEndpoint{
-								{
-									Name: string(hyperv1beta1.OAuthServer),
-									URL:  "oauth.example.com",
-								},
+					Services: []hyperv1beta1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1beta1.APIServer,
+							ServicePublishingStrategy: hyperv1beta1.ServicePublishingStrategy{
+								Type: hyperv1beta1.NodePort,
 							},
 						},
 					},


### PR DESCRIPTION
The individual commits in this PR correspond to:

* Deleting a `VpcEndpointTemplate` wasn't waiting for the child `VpcEndpoints` to be deleted (and deletion wasn't even working). A finalizer was added and the deletion code was fixed.
* The DNS hostname of a hosted cluster's API Server was being read from an incorrect location on the `hostedcontroplane` CR
* The AWS Route53 API is pretty inconsistent with where it wants a Hosted Zone id vs one like `/hostedzone/${id}` and we were getting it wrong in some places
* The VpcEndpointTemplate controller is pretty spammy with a specific log line as it processes each `hostedcluster`, so I've moved that to the debug log level.
* VPC/Subnet auto-selection wasn't accounting for the possibility of there being viable subnets across different VPCs correctly (i.e., we should only find viable subnets within a single VPC)

[OSD-15666](https://issues.redhat.com//browse/OSD-15666)