### PR TITLE
Fix logic preventing creation of Route53 Hosted Zones + VPC Endpoints per HostedCluster

### DIFF
--- a/controllers/vpcendpoint/cleanup.go
+++ b/controllers/vpcendpoint/cleanup.go
@@ -80,7 +80,7 @@ func (r *VpcEndpointReconciler) cleanupAwsResources(ctx context.Context, resourc
 
 	if resource.Status.HostedZoneId != "" {
 		// Only delete a Route53 Private Hosted Zone if AVO created it
-		if resource.Spec.CustomDns.Route53PrivateHostedZone.DomainName != "" {
+		if resource.Spec.CustomDns.Route53PrivateHostedZone.DomainName != "" || resource.Spec.CustomDns.Route53PrivateHostedZone.DomainNameRef != nil {
 			if _, err := r.awsClient.DeleteHostedZone(ctx, resource.Status.HostedZoneId); err != nil {
 				return err
 			}

--- a/pkg/hostedcontrolplanes/hostedcontrolplanes_test.go
+++ b/pkg/hostedcontrolplanes/hostedcontrolplanes_test.go
@@ -25,6 +25,68 @@ import (
 	"testing"
 )
 
+func TestGetInfraId(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		hcp       *hyperv1beta1.HostedControlPlane
+		expected  string
+		expectErr bool
+	}{
+		{
+			name:      "working",
+			namespace: "example",
+			hcp: &hyperv1beta1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "example",
+				},
+				Spec: hyperv1beta1.HostedControlPlaneSpec{
+					InfraID: "mycluster",
+				},
+			},
+			expected:  "mycluster",
+			expectErr: false,
+		},
+		{
+			name:      "empty infraId",
+			namespace: "example",
+			hcp: &hyperv1beta1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "example",
+				},
+				Spec: hyperv1beta1.HostedControlPlaneSpec{},
+			},
+			expectErr: true,
+		},
+		{
+			name:      "no hostedcontrolplane",
+			namespace: "example",
+			hcp: &hyperv1beta1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "example2",
+				},
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mock := testutil.NewTestMock(t, test.hcp)
+			actual, err := GetInfraId(context.TODO(), mock.Client, test.namespace)
+			if test.expectErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, test.expected, actual)
+			}
+		})
+	}
+}
+
 func TestGetPrivateHostedZoneDomainName(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -48,7 +110,7 @@ func TestGetPrivateHostedZoneDomainName(t *testing.T) {
 							ServicePublishingStrategy: hyperv1beta1.ServicePublishingStrategy{
 								Type: hyperv1beta1.Route,
 								Route: &hyperv1beta1.RoutePublishingStrategy{
-									Hostname: "example.com",
+									Hostname: "api.example.com",
 								},
 							},
 						},


### PR DESCRIPTION
This PR grabs the infra id from the `hostedcontrolplane` CR when `Spec.CustomDns.Route53PrivateHostedZone.DomainNameRef.ValueFrom.HostedControlPlaneRef` is filled out. This results in the correct behavior of one VPCE being created per `hostedcluster` as previously the VPCE's were being created based on the underlying management cluster's infra id.

Furthermore, the domain name on the `hostedcontrolplane` CR already contains the subdomain "api", so updated the parsing logic so that the subdomain is omitted when determining the base domain for the private Route53 hosted zone. The result is a clean creation/deletion flow of `VpcEndpointTemplate`s without leaking resources in Route53!

[OSD-15666](https://issues.redhat.com//browse/OSD-15666)