### PR TITLE
Store cluster infra id in .status.infraId

### DIFF
--- a/api/v1alpha2/vpcendpoint_types.go
+++ b/api/v1alpha2/vpcendpoint_types.go
@@ -297,6 +297,10 @@ type VpcEndpointStatus struct {
 	// +kubebuilder:validation:Optional
 	ResourceRecordSet string `json:"resourceRecordSet,omitempty"`
 
+	// The Infra Id of the cluster, used for naming and tagging purposes
+	// +kubebuilder:validation:Optional
+	InfraId string `json:"infraId,omitempty"`
+
 	// The status conditions of the AWS and K8s resources managed by this controller
 	// +kubebuilder:validation:Optional
 	Conditions []metav1.Condition `json:"conditions"`

--- a/controllers/vpcendpoint/helpers_test.go
+++ b/controllers/vpcendpoint/helpers_test.go
@@ -37,10 +37,9 @@ import (
 
 func TestVpcEndpointReconciler_findOrCreateSecurityGroup(t *testing.T) {
 	tests := []struct {
-		name        string
-		resource    *avov1alpha2.VpcEndpoint
-		clusterInfo *clusterInfo
-		expectErr   bool
+		name      string
+		resource  *avov1alpha2.VpcEndpoint
+		expectErr bool
 	}{
 		{
 			name: "SecurityGroupID populated",
@@ -60,10 +59,9 @@ func TestVpcEndpointReconciler_findOrCreateSecurityGroup(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "mock2",
 				},
-				Status: avov1alpha2.VpcEndpointStatus{},
-			},
-			clusterInfo: &clusterInfo{
-				infraName: testutil.MockInfrastructureName,
+				Status: avov1alpha2.VpcEndpointStatus{
+					InfraId: testutil.MockInfrastructureName,
+				},
 			},
 			expectErr: false,
 		},
@@ -72,12 +70,11 @@ func TestVpcEndpointReconciler_findOrCreateSecurityGroup(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			r := &VpcEndpointReconciler{
-				Client:      testutil.NewTestMock(t, test.resource).Client,
-				Scheme:      testutil.NewTestMock(t).Client.Scheme(),
-				Recorder:    record.NewFakeRecorder(1),
-				log:         testr.New(t),
-				awsClient:   aws_client.NewMockedAwsClient(),
-				clusterInfo: test.clusterInfo,
+				Client:    testutil.NewTestMock(t, test.resource).Client,
+				Scheme:    testutil.NewTestMock(t).Client.Scheme(),
+				Recorder:  record.NewFakeRecorder(1),
+				log:       testr.New(t),
+				awsClient: aws_client.NewMockedAwsClient(),
 			}
 
 			_, err := r.findOrCreateSecurityGroup(context.TODO(), test.resource)
@@ -123,11 +120,13 @@ func TestVpcEndpointReconciler_createMissingSecurityGroupTags(t *testing.T) {
 			},
 			clusterInfo: &clusterInfo{
 				clusterTag: aws_client.MockClusterTag,
-				infraName:  testutil.MockInfrastructureName,
 			},
 			resource: &avov1alpha2.VpcEndpoint{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "mock1",
+				},
+				Status: avov1alpha2.VpcEndpointStatus{
+					InfraId: testutil.MockInfrastructureName,
 				},
 			},
 		},
@@ -144,11 +143,13 @@ func TestVpcEndpointReconciler_createMissingSecurityGroupTags(t *testing.T) {
 			},
 			clusterInfo: &clusterInfo{
 				clusterTag: aws_client.MockClusterTag,
-				infraName:  testutil.MockInfrastructureName,
 			},
 			resource: &avov1alpha2.VpcEndpoint{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "mock2",
+				},
+				Status: avov1alpha2.VpcEndpointStatus{
+					InfraId: testutil.MockInfrastructureName,
 				},
 			},
 		},
@@ -178,7 +179,6 @@ func TestVpcEndpointReconciler_createMissingSecurityGroupTags(t *testing.T) {
 func TestVpcEndpointReconciler_generateMissingSecurityGroupRules(t *testing.T) {
 	tests := []struct {
 		name               string
-		clusterInfo        *clusterInfo
 		resource           *avov1alpha2.VpcEndpoint
 		sg                 *ec2Types.SecurityGroup
 		expectedNumIngress int
@@ -191,9 +191,6 @@ func TestVpcEndpointReconciler_generateMissingSecurityGroupRules(t *testing.T) {
 		},
 		{
 			name: "valid",
-			clusterInfo: &clusterInfo{
-				infraName: testutil.MockInfrastructureName,
-			},
 			resource: &avov1alpha2.VpcEndpoint{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "mock1",
@@ -228,6 +225,9 @@ func TestVpcEndpointReconciler_generateMissingSecurityGroupRules(t *testing.T) {
 						},
 					},
 				},
+				Status: avov1alpha2.VpcEndpointStatus{
+					InfraId: testutil.MockInfrastructureName,
+				},
 			},
 			sg: &ec2Types.SecurityGroup{
 				GroupId: aws.String(aws_client.MockSecurityGroupId),
@@ -249,7 +249,7 @@ func TestVpcEndpointReconciler_generateMissingSecurityGroupRules(t *testing.T) {
 				Scheme:      client.Scheme(),
 				log:         testr.New(t),
 				awsClient:   aws_client.NewMockedAwsClient(),
-				clusterInfo: test.clusterInfo,
+				clusterInfo: &clusterInfo{},
 			}
 
 			ingress, egress, err := r.generateMissingSecurityGroupRules(context.TODO(), test.sg, test.resource)
@@ -340,12 +340,12 @@ func TestVpcEndpointReconciler_findOrCreateVpcEndpoint(t *testing.T) {
 					Name: "mock2",
 				},
 				Status: avov1alpha2.VpcEndpointStatus{
-					VPCId: aws_client.MockVpcId,
+					VPCId:   aws_client.MockVpcId,
+					InfraId: testutil.MockInfrastructureName,
 				},
 			},
 			clusterInfo: &clusterInfo{
 				clusterTag: aws_client.MockClusterTag,
-				infraName:  testutil.MockInfrastructureName,
 			},
 			expectErr: false,
 		},

--- a/controllers/vpcendpoint/validation_test.go
+++ b/controllers/vpcendpoint/validation_test.go
@@ -177,6 +177,7 @@ func TestVPCEndpointReconciler_validateSecurityGroup(t *testing.T) {
 				},
 				Status: avov1alpha2.VpcEndpointStatus{
 					SecurityGroupId: aws_client.MockSecurityGroupId,
+					InfraId:         testutil.MockInfrastructureName,
 				},
 			},
 			expectErr: false,
@@ -195,7 +196,6 @@ func TestVPCEndpointReconciler_validateSecurityGroup(t *testing.T) {
 			log:       testr.New(t),
 			clusterInfo: &clusterInfo{
 				clusterTag: aws_client.MockClusterTag,
-				infraName:  testutil.MockInfrastructureName,
 			},
 			Recorder: record.NewFakeRecorder(1),
 		}

--- a/controllers/vpcendpoint/vpcendpoint_controller.go
+++ b/controllers/vpcendpoint/vpcendpoint_controller.go
@@ -55,9 +55,6 @@ type clusterInfo struct {
 	// clusterTag is the tag that uniquely identifies AWS resources for this cluster
 	// e.g. "kubernetes.io/cluster/${infraName}"
 	clusterTag string
-	// infraName is the name shown in the cluster's infrastructures CR
-	// e.g. "${clusterName}-abcd"
-	infraName string
 	// region is the AWS region for the cluster
 	region string
 }

--- a/deploy/crds/avo.openshift.io_vpcendpoints.yaml
+++ b/deploy/crds/avo.openshift.io_vpcendpoints.yaml
@@ -630,6 +630,10 @@ spec:
                 description: The AWS ID of the Route 53 Private Hosted Zone being
                   used
                 type: string
+              infraId:
+                description: The Infra Id of the cluster, used for naming and tagging
+                  purposes
+                type: string
               resourceRecordSet:
                 description: The FQDN of a Route 53 Hosted Zone record that has been
                   created

--- a/pkg/util/naming.go
+++ b/pkg/util/naming.go
@@ -88,6 +88,9 @@ func GetClusterTagKey(infraName string) (string, error) {
 // GenerateSecurityGroupName generates a name for a security group given a cluster name
 // and a "purpose" for the security group
 func GenerateSecurityGroupName(clusterName, purpose string) (string, error) {
+	if clusterName == "" {
+		return "", errors.New("clusterName must not be empty when generating a security group name")
+	}
 	prefix := fmt.Sprintf("%s-%s", clusterName, purpose)
 	return generateName(prefix, "sg", 255)
 }
@@ -95,6 +98,9 @@ func GenerateSecurityGroupName(clusterName, purpose string) (string, error) {
 // GenerateVPCEndpointName generates a name for a VPC endpoint given a cluster name
 // and a "purpose" for the VPC endpoint
 func GenerateVPCEndpointName(clusterName, purpose string) (string, error) {
+	if clusterName == "" {
+		return "", errors.New("clusterName must not be empty when generating a vpc endpoint name")
+	}
 	prefix := fmt.Sprintf("%s-%s", clusterName, purpose)
 	return generateName(prefix, "vpce", 255)
 }

--- a/pkg/util/naming_test.go
+++ b/pkg/util/naming_test.go
@@ -138,6 +138,11 @@ func TestGenerateSecurityGroupName(t *testing.T) {
 			expected:    fmt.Sprintf("cluster-%s-sg", strings.Repeat("a", 244)),
 			expectErr:   false,
 		},
+		{
+			clusterName: "",
+			purpose:     "test",
+			expectErr:   true,
+		},
 	}
 
 	for _, test := range tests {
@@ -169,6 +174,11 @@ func TestGenerateVPCEndpointName(t *testing.T) {
 			purpose:     strings.Repeat("a", 255),
 			expected:    fmt.Sprintf("cluster-%s-vpce", strings.Repeat("a", 242)),
 			expectErr:   false,
+		},
+		{
+			clusterName: "",
+			purpose:     "test",
+			expectErr:   true,
 		},
 	}
 


### PR DESCRIPTION
This commit fixes a race condition during VpcEndpoint deletion when the backing CustomResources which holds the infra id is deleted before the VpcEndpoint. By storing the infra id in the VpcEndpoint's own status field, the deletion of these objects can continue regardless of whether the infrastructure or hostedcontrolplane CRs are deleted first.

[OSD-16820](https://issues.redhat.com//browse/OSD-16820)