### PR TITLE
Ignore missing awsendpointservice if status field is already set

### DIFF
--- a/controllers/vpcendpoint/helpers.go
+++ b/controllers/vpcendpoint/helpers.go
@@ -209,7 +209,13 @@ func (r *VpcEndpointReconciler) getVpcEndpointServiceName(ctx context.Context, v
 			Namespace: vpce.Namespace,
 			Name:      vpce.Spec.ServiceNameRef.ValueFrom.AwsEndpointServiceRef.Name,
 		}, awsEndpointService); err != nil {
-			return err
+			if vpce.Status.VPCEndpointServiceName == "" {
+				return err
+			}
+
+			// If we already have a VpcEndpointService name set in status, ignore this error in case the
+			// awsendpointservice gets deleted before the VpcEndpoint
+			return nil
 		}
 		vpceServiceName = awsEndpointService.Status.EndpointServiceName
 	}


### PR DESCRIPTION
After the bugfix in #186, cleanup is now failing with:

```json
{"level":"error","ts":"2023-06-09T17:53:30Z","msg":"Reconciler error","controller":"vpcendpoint","controllerGroup":"avo.openshift.io","controllerKind":"VpcEndpoint","vpcEndpoint":{"name":"private-hcp","namespace":"REDACTED"},"namespace":"REDACTED","name":"private-hcp","reconcileID":"af05d6d7-42f7-4bb6-8247-3f139721b3f4","error":"AWSEndpointService.hypershift.openshift.io \"private-router\" not found"}
```

In observed cases, the status field is already populated. We can ignore this error in these cases.

[OSD-16820](https://issues.redhat.com//browse/OSD-16820) 