### PR TITLE
Fix bug preventing decoding of AvoConfig

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -328,9 +328,9 @@ objects:
           name: avo-config
           namespace: openshift-aws-vpce-operator
         data:
-          avo_config.yaml: |
-            apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
-            kind: ControllerManagerConfig
+          avo_config.yaml: |-
+            apiVersion: avo.openshift.io/v1alpha1
+            kind: AvoConfig
             enableVpcEndpointController: true
             enableVpcEndpointAcceptanceController: false
             enableVpcEndpointTemplateController: true


### PR DESCRIPTION
We were using the incorrect kind/apiVersion for successful decoding and getting this in the logs:

```json
{"level":"error","ts":"2023-07-05T17:17:40Z","logger":"setup","msg":"unable to load config file, continuing with defaults","file":"/avo/avo_config.yaml","error":"could not decode file into runtime.Object"}
```

[OSD-17334](https://issues.redhat.com//browse/OSD-17334)