### PR TITLE
Make catalogsource compatible with restricted SCC enforcement

### DIFF
--- a/hack/olm-registry/olm-artifacts-hypershift-template.yaml
+++ b/hack/olm-registry/olm-artifacts-hypershift-template.yaml
@@ -121,6 +121,7 @@ objects:
       spec:
         image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
         grpcPodConfig:
+          securityContextConfig: restricted
           nodeSelector:
             node-role.kubernetes.io: infra
           tolerations:

--- a/hack/olm-registry/olm-artifacts-template-fedramp.yaml
+++ b/hack/olm-registry/olm-artifacts-template-fedramp.yaml
@@ -73,6 +73,7 @@ objects:
   spec:
     image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
     grpcPodConfig:
+      securityContextConfig: restricted
       nodeSelector:
         node-role.kubernetes.io: infra
       tolerations:

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -117,6 +117,7 @@ objects:
       spec:
         image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
         grpcPodConfig:
+          securityContextConfig: restricted
           nodeSelector:
             node-role.kubernetes.io: infra
           tolerations:
@@ -251,6 +252,7 @@ objects:
       spec:
         image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
         grpcPodConfig:
+          securityContextConfig: restricted
           nodeSelector:
             node-role.kubernetes.io: infra
           tolerations:


### PR DESCRIPTION
* Restricted SCC enforcement will be added with OCP 4.14
* Updating the catalogsource to allow the operator to get deployed
* Clusters that don't support the setting (<4.12) will ignore it

Jira: [OSD-17471](https://issues.redhat.com//browse/OSD-17471)