### PR TITLE
Add KNOWN_SECTORS parameter to default HyperShift template

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -18,6 +18,9 @@ parameters:
 - name: DISPLAY_NAME
   value: AWS VPCE Operator
   required: true
+- name: KNOWN_SECTORS
+  value: "['main']"
+  required: true
 
 objects:
 ###############
@@ -186,10 +189,13 @@ objects:
           values:
             - "management-cluster"
             - "service-cluster"
+        - key: ext-hypershift.openshift.io/cluster-sector
+          operator: NotIn
+          values: "${{KNOWN_SECTORS}}"
         - key: api.openshift.com/fedramp
           operator: NotIn
           values: ["true"]
-    resourceApplyMode: Sync
+    resourceApplyMode: Upsert
     resources:
     - kind: Namespace
       apiVersion: v1


### PR DESCRIPTION
This parameter will exclude this SSS from deploying to "known" sectors, i.e. sectors that we would otherwise want to roll out progressively.

[SDCICD-991](https://issues.redhat.com//browse/SDCICD-991)