### PR TITLE
Use correct syntax to supply an array of strings

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -19,7 +19,7 @@ parameters:
   value: AWS VPCE Operator
   required: true
 - name: KNOWN_SECTORS
-  value: "['main']"
+  value: '["main"]'
   required: true
 
 objects:


### PR DESCRIPTION
[SDCICD-991](https://issues.redhat.com//browse/SDCICD-991)

Tested using `oc process -f ${template}`, the original quotes resulted in:
```
values: '[''main'']'
```

While the new quotes result in:
```
values:
    - main
    - test
```