### PR TITLE
Add a way for AVO to use sts:AssumeRole when instructed

### DIFF
--- a/api/v1alpha2/vpcendpoint_types.go
+++ b/api/v1alpha2/vpcendpoint_types.go
@@ -238,7 +238,10 @@ type VpcEndpointSpec struct {
 	// +kubebuilder:validation:Optional
 
 	// AWSCredentialOverride is a Kubernetes secret containing AWS credentials for the operator to use for reconciling
-	// this specific vpcendpoint Custom Resource
+	// this specific vpcendpoint Custom Resource.
+	// The secret should have data keys for either:
+	// * role_arn: The operator will attempt to assume this role
+	// * aws_access_key_id and aws_secret_access_key: The operator will simply use these IAM User credentials
 	AWSCredentialOverrideRef *corev1.SecretReference `json:"awsCredentialOverrideRef,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/deploy/crds/avo.openshift.io_vpcendpoints.yaml
+++ b/deploy/crds/avo.openshift.io_vpcendpoints.yaml
@@ -257,9 +257,12 @@ spec:
                   create VPC Endpoints in separate AWS Accounts TODO: Implement'
                 type: string
               awsCredentialOverrideRef:
-                description: AWSCredentialOverride is a Kubernetes secret containing
+                description: 'AWSCredentialOverride is a Kubernetes secret containing
                   AWS credentials for the operator to use for reconciling this specific
-                  vpcendpoint Custom Resource
+                  vpcendpoint Custom Resource. The secret should have data keys for
+                  either: * role_arn: The operator will attempt to assume this role
+                  * aws_access_key_id and aws_secret_access_key: The operator will
+                  simply use these IAM User credentials'
                 properties:
                   name:
                     description: name is unique within a namespace to reference a

--- a/deploy/crds/avo.openshift.io_vpcendpointtemplates.yaml
+++ b/deploy/crds/avo.openshift.io_vpcendpointtemplates.yaml
@@ -117,9 +117,12 @@ spec:
                           to create VPC Endpoints in separate AWS Accounts TODO: Implement'
                         type: string
                       awsCredentialOverrideRef:
-                        description: AWSCredentialOverride is a Kubernetes secret
+                        description: 'AWSCredentialOverride is a Kubernetes secret
                           containing AWS credentials for the operator to use for reconciling
-                          this specific vpcendpoint Custom Resource
+                          this specific vpcendpoint Custom Resource. The secret should
+                          have data keys for either: * role_arn: The operator will
+                          attempt to assume this role * aws_access_key_id and aws_secret_access_key:
+                          The operator will simply use these IAM User credentials'
                         properties:
                           name:
                             description: name is unique within a namespace to reference


### PR DESCRIPTION
The .spec.awsCredentialOverrideRef field already exists in our API, but previously only acts on IAM User credentials that are provided. This commit adds the ability to parse role_arn from the provided secret and perform sts:AssumeRole instead.

[OSD-18773](https://issues.redhat.com//browse/OSD-18773)