### PR TITLE
OSD-18595 check other vpce custom domains

### DIFF
--- a/controllers/vpcendpoint/cleanup.go
+++ b/controllers/vpcendpoint/cleanup.go
@@ -92,7 +92,7 @@ func (r *VpcEndpointReconciler) cleanupAwsResources(ctx context.Context, resourc
 		if resource.Spec.CustomDns.Route53PrivateHostedZone.DomainName != "" || resource.Spec.CustomDns.Route53PrivateHostedZone.DomainNameRef != nil {
 			// don't delete the zone if it's the cluster's private zone
 			dnsConfig := &configv1.DNS{}
-			err := r.Client.Get(context.TODO(), client.ObjectKey{Name: clusterDNSName}, dnsConfig)
+			err := r.Client.Get(ctx, client.ObjectKey{Name: clusterDNSName}, dnsConfig)
 			if err != nil {
 				return err
 			}
@@ -104,7 +104,7 @@ func (r *VpcEndpointReconciler) cleanupAwsResources(ctx context.Context, resourc
 					Type: route53Types.RRTypeA,
 				}
 
-				_, err := r.awsClient.DeleteResourceRecordSet(context.TODO(), rrSet, resource.Spec.CustomDns.Route53PrivateHostedZone.Id)
+				_, err := r.awsClient.DeleteResourceRecordSet(ctx, rrSet, resource.Spec.CustomDns.Route53PrivateHostedZone.Id)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
This adds a check to see if another vpce resource on the cluster is
using the same custom domain and if so, only remove the selected record
(not the entire zone).