### PR TITLE
[OSD-19645]  AVO startup race condition when role_arn is not available

### DIFF
--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -38,9 +38,9 @@ func DefaultAVORateLimiter() workqueue.RateLimiter {
 	)
 }
 
-// AWSEnvVarReadyzChecker is a healthz.Checker that returns an error if there are not enough environment variables
+// AWSEnvVarHealtzChecker is a healthz.Checker that returns an error if there are not enough environment variables
 // set to create an AWS client for this operator to function.
-func AWSEnvVarReadyzChecker(_ *http.Request) error {
+func AWSEnvVarHealtzChecker(_ *http.Request) error {
 	// These two in combination allow non-STS clusters to get the necessary credentials
 	if _, ok := os.LookupEnv("AWS_SECRET_ACCESS_KEY"); ok {
 		if _, ok := os.LookupEnv("AWS_ACCESS_KEY_ID"); ok {

--- a/controllers/util/util_test.go
+++ b/controllers/util/util_test.go
@@ -42,7 +42,7 @@ func TestDefaultAVORateLimiter(t *testing.T) {
 	}
 }
 
-func TestAWSEnvVarReadyzChecker(t *testing.T) {
+func TestAWSEnvVarHealtzChecker(t *testing.T) {
 	tests := []struct {
 		name      string
 		env       map[string]string
@@ -79,7 +79,7 @@ func TestAWSEnvVarReadyzChecker(t *testing.T) {
 			for k, v := range test.env {
 				t.Setenv(k, v)
 			}
-			actual := AWSEnvVarReadyzChecker(&http.Request{})
+			actual := AWSEnvVarHealtzChecker(&http.Request{})
 			if actual != nil {
 				if !test.expectErr {
 					t.Fatalf("expected no error, got %s", actual)

--- a/deploy/20_operator.yaml
+++ b/deploy/20_operator.yaml
@@ -68,6 +68,7 @@ spec:
               port: 8081
             initialDelaySeconds: 15
             periodSeconds: 20
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /readyz

--- a/main.go
+++ b/main.go
@@ -162,11 +162,11 @@ func main() {
 	}
 	//+kubebuilder:scaffold:builder
 
-	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+	if err := mgr.AddHealthzCheck("healthz", util.AWSEnvVarHealtzChecker); err != nil {
 		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)
 	}
-	if err := mgr.AddReadyzCheck("readyz", util.AWSEnvVarReadyzChecker); err != nil {
+	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -56,7 +56,7 @@ func ParseAWSCredentialOverride(ctx context.Context, c client.Reader, region str
 		// https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/credentials/stscreds#hdr-Assume_Role
 		cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
 		if err != nil {
-			return aws.Config{}, err
+			return aws.Config{}, fmt.Errorf("Failed to build AWS client. Error: %v", err)
 		}
 		stsSvc := sts.NewFromConfig(cfg)
 		creds := stscreds.NewAssumeRoleProvider(stsSvc, string(roleArn))


### PR DESCRIPTION
In this commit, I added a fix for [OSD-19645]  AVO startup race condition when role_arn is not available 

https://issues.redhat.com/browse/OSD-19645