### PR TITLE
remove unknown fields from CatalogSource definition

### DIFF
--- a/hack/olm-registry/olm-artifacts-hypershift-template.yaml
+++ b/hack/olm-registry/olm-artifacts-hypershift-template.yaml
@@ -128,18 +128,6 @@ objects:
             - effect: NoSchedule
               key: node-role.kubernetes.io/infra
               operator: Exists
-        affinity:
-          nodeAffinity:
-            preferredDuringSchedulingIgnoredDuringExecution:
-            - preference:
-                matchExpressions:
-                - key: node-role.kubernetes.io/infra
-                  operator: Exists
-              weight: 1
-        tolerations:
-        - operator: Exists
-          key: node-role.kubernetes.io/infra
-          effect: NoSchedule
         displayName: ${REPO_NAME}
         icon:
           base64data: ''

--- a/hack/olm-registry/olm-artifacts-template-fedramp.yaml
+++ b/hack/olm-registry/olm-artifacts-template-fedramp.yaml
@@ -80,18 +80,6 @@ objects:
         - effect: NoSchedule
           key: node-role.kubernetes.io/infra
           operator: Exists
-    affinity:
-      nodeAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-        - preference:
-            matchExpressions:
-            - key: node-role.kubernetes.io/infra
-              operator: Exists
-          weight: 1
-    tolerations:
-    - operator: Exists
-      key: node-role.kubernetes.io/infra
-      effect: NoSchedule
     displayName: ${REPO_NAME}
     icon:
       base64data: ''

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -127,18 +127,6 @@ objects:
             - effect: NoSchedule
               key: node-role.kubernetes.io/infra
               operator: Exists
-        affinity:
-          nodeAffinity:
-            preferredDuringSchedulingIgnoredDuringExecution:
-            - preference:
-                matchExpressions:
-                - key: node-role.kubernetes.io/infra
-                  operator: Exists
-              weight: 1
-        tolerations:
-        - operator: Exists
-          key: node-role.kubernetes.io/infra
-          effect: NoSchedule
         displayName: ${REPO_NAME}
         icon:
           base64data: ''
@@ -265,18 +253,6 @@ objects:
             - effect: NoSchedule
               key: node-role.kubernetes.io/infra
               operator: Exists
-        affinity:
-          nodeAffinity:
-            preferredDuringSchedulingIgnoredDuringExecution:
-            - preference:
-                matchExpressions:
-                - key: node-role.kubernetes.io/infra
-                  operator: Exists
-              weight: 1
-        tolerations:
-        - operator: Exists
-          key: node-role.kubernetes.io/infra
-          effect: NoSchedule
         displayName: ${REPO_NAME}
         icon:
           base64data: ''


### PR DESCRIPTION
These fields have never existed on the CatalogSource spec going back to OCP 4.4 and we handle this scheduling constraing within grpcPodConfig

https://docs.openshift.com/container-platform/4.14/rest_api/operatorhub_apis/catalogsource-operators-coreos-com-v1alpha1.html

[SDCICD-1178](https://issues.redhat.com//browse/SDCICD-1178)