### PR TITLE
OSD-24970: updates sg rule logic to ignore ip-source rules

### DIFF
--- a/controllers/vpcendpoint/helpers.go
+++ b/controllers/vpcendpoint/helpers.go
@@ -396,6 +396,9 @@ func (r *VpcEndpointReconciler) generateMissingSecurityGroupRules(ctx context.Co
 				create := true
 				for _, rule := range rulesResp.SecurityGroupRules {
 					if avoAndAwsSecurityGroupRuleCandidate(false, resource.Spec.SecurityGroup.IngressRules[i], rule) {
+						if rule.ReferencedGroupInfo == nil {
+							continue
+						}
 						if *rule.ReferencedGroupInfo.GroupId == *sourceSgId {
 							// If we find a rule with the correct protocol, fromPort, and toPort, check the source security group
 							create = false
@@ -451,6 +454,9 @@ func (r *VpcEndpointReconciler) generateMissingSecurityGroupRules(ctx context.Co
 				create := true
 				for _, rule := range rulesResp.SecurityGroupRules {
 					if avoAndAwsSecurityGroupRuleCandidate(true, resource.Spec.SecurityGroup.IngressRules[i], rule) {
+						if rule.ReferencedGroupInfo == nil {
+							continue
+						}
 						if *rule.ReferencedGroupInfo.GroupId == *sourceSgId {
 							// If we find a rule with the correct protocol, fromPort, and toPort, check the source security group
 							create = false

--- a/controllers/vpcendpoint/helpers_test.go
+++ b/controllers/vpcendpoint/helpers_test.go
@@ -190,7 +190,7 @@ func TestVpcEndpointReconciler_generateMissingSecurityGroupRules(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name: "valid",
+			name: "can generate security group rules successfully",
 			resource: &avov1alpha2.VpcEndpoint{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "mock1",

--- a/pkg/aws_client/mock.go
+++ b/pkg/aws_client/mock.go
@@ -182,9 +182,41 @@ func (m *MockedEC2) DescribeSecurityGroups(ctx context.Context, params *ec2.Desc
 }
 
 func (m *MockedEC2) DescribeSecurityGroupRules(ctx context.Context, params *ec2.DescribeSecurityGroupRulesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSecurityGroupRulesOutput, error) {
-	// TODO: This is a no-op
+	// Mock now contains "pre-existing" rules to ensure SG rules created by customer using IP's over SGs do not cause failures
+	// while reconciling security group rules
 	return &ec2.DescribeSecurityGroupRulesOutput{
-		SecurityGroupRules: []ec2Types.SecurityGroupRule{},
+		SecurityGroupRules: []ec2Types.SecurityGroupRule{
+			ec2Types.SecurityGroupRule{
+				CidrIpv4:            aws.String("0.0.0.0/0"),
+				CidrIpv6:            nil,
+				Description:         aws.String("bad rule with no source SG"),
+				FromPort:            aws.Int32(1),
+				GroupId:             nil,
+				GroupOwnerId:        nil,
+				IpProtocol:          aws.String("tcp"),
+				IsEgress:            aws.Bool(false),
+				PrefixListId:        nil,
+				ReferencedGroupInfo: nil,
+				SecurityGroupRuleId: nil,
+				Tags:                nil,
+				ToPort:              aws.Int32(1),
+			},
+			ec2Types.SecurityGroupRule{
+				CidrIpv4:            aws.String("0.0.0.0/0"),
+				CidrIpv6:            nil,
+				Description:         aws.String("bad rule with no source SG"),
+				FromPort:            aws.Int32(1),
+				GroupId:             nil,
+				GroupOwnerId:        nil,
+				IpProtocol:          aws.String("tcp"),
+				IsEgress:            aws.Bool(true),
+				PrefixListId:        nil,
+				ReferencedGroupInfo: nil,
+				SecurityGroupRuleId: nil,
+				Tags:                nil,
+				ToPort:              aws.Int32(1),
+			},
+		},
 	}, nil
 }
 


### PR DESCRIPTION
For [OSD-24970](https://issues.redhat.com//browse/OSD-24970):
* updates logic for when AVO finds existing rules in an SG that do not contain a security group for the source
  *  this is to accommodate for when/if a customer adds rules to an SG that does not align with the operators expectations
* updates Mock to define some "pre-existing" rules for testing this scenario 