### PR TITLE
Add Role & RoleBinding for additional CSV permission admission

### DIFF
--- a/deploy/17_role.yaml
+++ b/deploy/17_role.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -10,3 +11,87 @@ rules:
     - secrets
     verbs:
     - get
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aws-vpce-operator
+  namespace: openshift-aws-vpce-operator
+rules:
+  - apiGroups:
+      - hypershift.openshift.io
+    resources:
+      - awsendpointservices
+      - hostedcontrolplanes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+    - config.openshift.io
+    resources:
+    - infrastructures
+    - dnses
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - aws.managed.openshift.io
+    resources:
+    - accounts
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - avo.openshift.io
+    resources:
+    - vpcendpoints
+    - vpcendpointacceptances
+    - vpcendpointtemplates
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+      - avo.openshift.io
+    resources:
+      - vpcendpoints/status
+      - vpcendpointacceptances/status
+      - vpcendpointtemplates/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - avo.openshift.io
+    resources:
+      - vpcendpoints/finalizers
+      - vpcendpointacceptances/finalizers
+      - vpcendpointtemplates/finalizers
+    verbs:
+      - update
+  - apiGroups:
+    - ""
+    resources:
+    - services
+    - services/finalizers
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - create

--- a/deploy/18_rolebinding.yaml
+++ b/deploy/18_rolebinding.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -11,3 +12,16 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: aws-vpce-operator-override-secret
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: aws-vpce-operator
+subjects:
+  - kind: ServiceAccount
+    name: aws-vpce-operator
+    namespace: openshift-aws-vpce-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: aws-vpce-operator


### PR DESCRIPTION
This adds an additional Role and RoleBinding to be used by boilerplate in generation of the CSV's `spec.install.spec.permissions` field.

Reference:
https://github.com/openshift/boilerplate/blob/master/boilerplate/openshift/golang-osd-operator/csv-generate/common-generate-operator-bundle.py#L312-L331