### PR TITLE
Add Namespace and Permissions Array to CSV Template

### DIFF
--- a/config/templates/csv-template.yaml
+++ b/config/templates/csv-template.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   name: aws-vpce-operator-0.0.1
-  namespace: placeholder
+  namespace: openshift-aws-vpce-operator
   annotations:
     categories: A list of comma separated categories that your operator falls under.
     certified: "false"
@@ -41,6 +41,9 @@ spec:
       deployments:
       - name: aws-vpce-operator
         # Deployment spec will be added here by boilerplate/openshift/golang-osd-operator/csv-generate
+      permissions:
+      - serviceAccountName: aws-vpce-operator
+        # Rules will be added here by boilerplate/openshift/golang-osd-operator/csv-generate
   customresourcedefinitions:
     owned:
     # CRD's will be added here by boilerplate/openshift/golang-osd-operator/csv-generate


### PR DESCRIPTION
Adding a namespace to the CSV template to ensure boilerplate generates non Cluster scoped permissions in the CSV