### PR TITLE
Relax AwsVPCEndpoint v1alpha1 CRD requirements 

### DIFF
--- a/api/v1alpha1/vpcendpoint_types.go
+++ b/api/v1alpha1/vpcendpoint_types.go
@@ -52,6 +52,7 @@ type VpcEndpointSpec struct {
 	// +kubebuilder:validation:MinLength=0
 
 	// ServiceName is the name of the VPC Endpoint Service to connect to
+	// +optional
 	ServiceName string `json:"serviceName"`
 
 	// SecurityGroup contains the configuration of the security group attached to the VPC Endpoint
@@ -60,9 +61,11 @@ type VpcEndpointSpec struct {
 	// +kubebuilder:validation:Pattern=[a-z0-9]([-a-z0-9]*[a-z0-9])?
 	// SubdomainName is the name of the Route53 Hosted Zone CNAME rule to create in the cluster's
 	// Private Route53 Hosted Zone
+	// +optional
 	SubdomainName string `json:"subdomainName"`
 
 	// ExternalNameService configures the name and namespace of the created Kubernetes ExternalName Service
+	// +optional
 	ExternalNameService ExternalNameServiceSpec `json:"externalNameService"`
 
 	// AddtlHostedZoneName is an optional FQDN to support supplemental VPCE routing via Route53 Private Hosted Zone

--- a/deploy/crds/avo.openshift.io_vpcendpoints.yaml
+++ b/deploy/crds/avo.openshift.io_vpcendpoints.yaml
@@ -137,10 +137,7 @@ spec:
                 pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
                 type: string
             required:
-            - externalNameService
             - securityGroup
-            - serviceName
-            - subdomainName
             type: object
           status:
             description: VpcEndpointStatus defines the observed state of VpcEndpoint


### PR DESCRIPTION
This will relax required fields for v1lalpha1 CRD to workaround an issue with OLM CR to CRD validations ([OCPBUGS-45143](https://issues.redhat.com/browse/OCPBUGS-45143)). This now will match v1 with v2 required fields.

This should hopefully fix:
```
$ oc get installplan -n openshift-aws-vpce-operator install-28bhg -o yaml
...
    reason: InstallComponentFailed
    status: "False"
    type: Installed
  message: 'error validating existing CRs against new CRD''s schema for "vpcendpoints.avo.openshift.io":
    error validating avo.openshift.io/v1alpha1, Kind=VpcEndpoint "ocm-staging-2f680nvupr68usru982fc94064oisj87-akanni-1039/private-hcp":
    updated validation is too restrictive: [[].spec.externalNameService: Required
    value, [].spec.serviceName: Required value, [].spec.subdomainName: Required value]'
```