### PR TITLE
SDE-4573: Enable OLM Skip Range

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -19,4 +19,6 @@ package config
 const (
 	OperatorName      string = "aws-vpce-operator"
 	OperatorNamespace string = "openshift-aws-vpce-operator"
+
+	EnableOLMSkipRange = "true"
 )


### PR DESCRIPTION
Configure boilerplate to generate an OLM bundle with a skip range pointing to the latest version. This will allow OLM to upgrade past broken replaces chains in which versions get abadoned without a path forward. The new OLM bundle will contain a single version, referencing the latest build with a `skipRange` to the version.