### PR TITLE
OHSS-42748 Support Additional Security Group Name Suffixes 

### DIFF
--- a/pkg/aws_client/security_group.go
+++ b/pkg/aws_client/security_group.go
@@ -37,6 +37,12 @@ func (c *AWSClient) FilterClusterNodeSecurityGroupsByDefaultTags(ctx context.Con
 		return nil, err
 	}
 
+	// Loop through the expected suffixes and generate the names based on the infra name
+	var nameValues []string
+	for i := 0; i < len(util.SupportedInfraIDSuffixes); i++ {
+		nameValues = append(nameValues, fmt.Sprintf(util.SupportedInfraIDSuffixes[i], infraName))
+	}
+
 	return c.ec2Client.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
 		Filters: []types.Filter{
 			{
@@ -44,11 +50,8 @@ func (c *AWSClient) FilterClusterNodeSecurityGroupsByDefaultTags(ctx context.Con
 				Values: []string{clusterTag},
 			},
 			{
-				Name: aws.String("tag:Name"),
-				Values: []string{
-					fmt.Sprintf("%s-master-sg", infraName),
-					fmt.Sprintf("%s-worker-sg", infraName),
-				},
+				Name:   aws.String("tag:Name"),
+				Values: nameValues,
 			},
 		},
 	})

--- a/pkg/util/naming.go
+++ b/pkg/util/naming.go
@@ -33,6 +33,10 @@ const (
 	SecurityGroupDescription = "Managed by AWS VPCE Operator"
 )
 
+// These are the expected security group suffixes available in the VPC based on the cluster's infra id.
+// NOTE: With 4.16+ the suffix changed to *-controlplane and *-node
+var SupportedInfraIDSuffixes = [...]string{"%s-master-sg", "%s-worker-sg", "%s-controlplane", "%s-node"}
+
 // GenerateAwsTags returns the tags that should be reconciled on every AWS resource
 // created by this operator
 func GenerateAwsTags(name, clusterTagKey string) ([]types.Tag, error) {


### PR DESCRIPTION
This supports additional suffixes for 4.16+ clusters. There will be follow on PRs to address unit testing and logging gaps as part of [OHSS-42748](https://issues.redhat.com//browse/OHSS-42748).