### PR TITLE
OSD-28836 Set applyBehavior to CreateOrUpdate

### DIFF
--- a/hack/olm-registry/olm-artifacts-hypershift-template.yaml
+++ b/hack/olm-registry/olm-artifacts-hypershift-template.yaml
@@ -59,6 +59,7 @@ objects:
           operator: NotIn
           values: ["true"]
     resourceApplyMode: Sync
+    applyBehavior: CreateOrUpdate
     resources:
     - kind: Namespace
       apiVersion: v1

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -58,6 +58,7 @@ objects:
           values:
             - "true"
     resourceApplyMode: Sync
+    applyBehavior: CreateOrUpdate
     resources:
     - kind: Namespace
       apiVersion: v1
@@ -185,6 +186,7 @@ objects:
           operator: NotIn
           values: ["true"]
     resourceApplyMode: Upsert
+    applyBehavior: CreateOrUpdate
     resources:
     - kind: Namespace
       apiVersion: v1
@@ -307,6 +309,7 @@ objects:
           operator: NotIn
           values: ["true"]
     resourceApplyMode: Sync
+    applyBehavior: CreateOrUpdate
     resources:
       - kind: ConfigMap
         apiVersion: v1


### PR DESCRIPTION
### Overview
Set apply mode to CreateOrUpdate to avoid conflicts between OLM and Hive.

### Background
By default hive will perform the equivalent of a kubectl apply when syncing a SSS. Swapping to the CreateOrUpdate mode will update hive to perform a kubectl patch - and this will prevent the issues we've been seeing.

(An in depth explanation can be found here: https://issues.redhat.com/browse/HIVE-2666?focusedId=26162937&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-26162937 )

### Fixes
https://issues.redhat.com/browse/OSD-28836