### PR TITLE
OSD-29372 Support New CAPI AWS Tag Key Naming Format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ FIPS_ENABLED=true
 # needed for FR operators as boilerplate checks commercial app-interface saas file hashes
 export SKIP_SAAS_FILE_CHECKS=y
 
+# TODO: Remove once OSD-29374 is fixed
+export TESTTARGETS=./...
+
 include boilerplate/generated-includes.mk
 
 SHELL := /usr/bin/env bash

--- a/controllers/vpcendpoint/helpers.go
+++ b/controllers/vpcendpoint/helpers.go
@@ -80,7 +80,7 @@ func (r *VpcEndpointReconciler) parseClusterInfo(ctx context.Context, vpce *avov
 		}
 	}
 
-	clusterTag, err := util.GetClusterTagKey(vpce.Status.InfraId)
+	clusterTag, err := util.GetClusterLegacyTagKey(vpce.Status.InfraId)
 	if err != nil {
 		return err
 	}

--- a/controllers/vpcendpoint/helpers_test.go
+++ b/controllers/vpcendpoint/helpers_test.go
@@ -109,7 +109,7 @@ func TestVpcEndpointReconciler_createMissingSecurityGroupTags(t *testing.T) {
 						Value: aws.String(util.OperatorTagValue),
 					},
 					{
-						Key:   aws.String(aws_client.MockClusterTag),
+						Key:   aws.String(aws_client.MockLegacyClusterTag),
 						Value: aws.String("owned"),
 					},
 					{
@@ -119,7 +119,7 @@ func TestVpcEndpointReconciler_createMissingSecurityGroupTags(t *testing.T) {
 				},
 			},
 			clusterInfo: &clusterInfo{
-				clusterTag: aws_client.MockClusterTag,
+				clusterTag: aws_client.MockLegacyClusterTag,
 			},
 			resource: &avov1alpha2.VpcEndpoint{
 				ObjectMeta: metav1.ObjectMeta{
@@ -142,7 +142,7 @@ func TestVpcEndpointReconciler_createMissingSecurityGroupTags(t *testing.T) {
 				},
 			},
 			clusterInfo: &clusterInfo{
-				clusterTag: aws_client.MockClusterTag,
+				clusterTag: aws_client.MockLegacyClusterTag,
 			},
 			resource: &avov1alpha2.VpcEndpoint{
 				ObjectMeta: metav1.ObjectMeta{
@@ -345,7 +345,7 @@ func TestVpcEndpointReconciler_findOrCreateVpcEndpoint(t *testing.T) {
 				},
 			},
 			clusterInfo: &clusterInfo{
-				clusterTag: aws_client.MockClusterTag,
+				clusterTag: aws_client.MockLegacyClusterTag,
 			},
 			expectErr: false,
 		},

--- a/controllers/vpcendpoint/validation.go
+++ b/controllers/vpcendpoint/validation.go
@@ -59,15 +59,18 @@ func (r *VpcEndpointReconciler) validateSecurityGroup(ctx context.Context, resou
 
 	sg, err := r.findOrCreateSecurityGroup(ctx, resource)
 	if err != nil {
+		r.log.V(0).Error(err, "failed to find or create security groups")
 		return err
 	}
 
 	if err := r.createMissingSecurityGroupTags(ctx, sg, resource); err != nil {
+		r.log.V(0).Error(err, "failed to create missing security group tags")
 		return err
 	}
 
 	ingressInput, egressInput, err := r.generateMissingSecurityGroupRules(ctx, sg, resource)
 	if err != nil {
+		r.log.V(0).Error(err, "failed to generate missing security group rules")
 		return err
 	}
 

--- a/controllers/vpcendpoint/validation_test.go
+++ b/controllers/vpcendpoint/validation_test.go
@@ -86,7 +86,7 @@ func TestVPCEndpointReconciler_validateSecurityGroup(t *testing.T) {
 			awsClient: aws_client.NewMockedAwsClientWithSubnets(),
 			log:       testr.New(t),
 			clusterInfo: &clusterInfo{
-				clusterTag: aws_client.MockClusterTag,
+				clusterTag: aws_client.MockLegacyClusterTag,
 			},
 			Recorder: record.NewFakeRecorder(1),
 		}
@@ -142,7 +142,7 @@ func TestVPCEndpointReconciler_validateVPCEndpoint(t *testing.T) {
 			awsClient: aws_client.NewMockedAwsClientWithSubnets(),
 			log:       testr.New(t),
 			clusterInfo: &clusterInfo{
-				clusterTag: aws_client.MockClusterTag,
+				clusterTag: aws_client.MockLegacyClusterTag,
 			},
 		}
 

--- a/pkg/aws_client/mock.go
+++ b/pkg/aws_client/mock.go
@@ -19,6 +19,7 @@ package aws_client
 import (
 	"context"
 	"fmt"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
@@ -28,7 +29,8 @@ import (
 )
 
 const (
-	MockClusterTag             = "kubernetes.io/cluster/mock-12345"
+	MockLegacyClusterTag       = "kubernetes.io/cluster/mock-12345"
+	MockCapiClusterTag         = "sigs.k8s.io/cluster-api-provider-aws/cluster/mock-54321"
 	MockClusterNameTag         = "mock-12345-vpce"
 	MockHostedZoneId           = "R53HZ12345"
 	MockPublicSubnetId         = "subnet-pub12345"
@@ -69,7 +71,7 @@ var mockSubnets = []*ec2Types.Subnet{
 				Value: nil,
 			},
 			{
-				Key:   aws.String(MockClusterTag),
+				Key:   aws.String(MockLegacyClusterTag),
 				Value: aws.String("shared"),
 			},
 		},
@@ -169,6 +171,20 @@ func (m *MockedEC2) DescribeSecurityGroups(ctx context.Context, params *ec2.Desc
 								{
 									Key:   aws.String(filter.Values[0]),
 									Value: nil,
+								},
+							},
+						},
+					},
+				}, nil
+			} else if *filter.Name == "Tag:Name" {
+				return &ec2.DescribeSecurityGroupsOutput{
+					SecurityGroups: []ec2Types.SecurityGroup{
+						{
+							GroupId: aws.String(MockSecurityGroupId),
+							Tags: []ec2Types.Tag{
+								{
+									Key:   aws.String("Name"),
+									Value: aws.String(filter.Values[0]),
 								},
 							},
 						},

--- a/pkg/aws_client/security_group.go
+++ b/pkg/aws_client/security_group.go
@@ -32,7 +32,12 @@ import (
 // FilterClusterNodeSecurityGroupsByDefaultTags describes the security groups attached to the cluster nodes
 // by filtering by the clusterTag and expected Name tags
 func (c *AWSClient) FilterClusterNodeSecurityGroupsByDefaultTags(ctx context.Context, infraName string) (*ec2.DescribeSecurityGroupsOutput, error) {
-	clusterTag, err := util.GetClusterTagKey(infraName)
+	clusterLegacyTag, err := util.GetClusterLegacyTagKey(infraName)
+	if err != nil {
+		return nil, err
+	}
+
+	clusterCapiTag, err := util.GetClusterCapiTagKey(infraName)
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +52,11 @@ func (c *AWSClient) FilterClusterNodeSecurityGroupsByDefaultTags(ctx context.Con
 		Filters: []types.Filter{
 			{
 				Name:   aws.String("tag-key"),
-				Values: []string{clusterTag},
+				Values: []string{clusterLegacyTag},
+			},
+			{
+				Name:   aws.String("tag-key"),
+				Values: []string{clusterCapiTag},
 			},
 			{
 				Name:   aws.String("tag:Name"),
@@ -60,7 +69,7 @@ func (c *AWSClient) FilterClusterNodeSecurityGroupsByDefaultTags(ctx context.Con
 // FilterSecurityGroupByDefaultTags describes the security group attached to the VPC Endpoint this operator manages
 // by filtering by the clusterTag and operator tag
 func (c *AWSClient) FilterSecurityGroupByDefaultTags(ctx context.Context, infraName, sgNameTag string) (*ec2.DescribeSecurityGroupsOutput, error) {
-	clusterTag, err := util.GetClusterTagKey(infraName)
+	clusterTag, err := util.GetClusterLegacyTagKey(infraName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/aws_client/security_group_test.go
+++ b/pkg/aws_client/security_group_test.go
@@ -25,11 +25,21 @@ import (
 
 func TestAWSClient_FilterClusterNodeSecurityGroupsByDefaultTags(t *testing.T) {
 	tests := []struct {
+		infraName string
 		tagKey    string
+		tagValue  string
 		expectErr bool
 	}{
 		{
-			tagKey:    MockClusterTag,
+			infraName: "mock-12345",
+			tagKey:    MockLegacyClusterTag,
+			tagValue:  "owned",
+			expectErr: false,
+		},
+		{
+			infraName: "mock-12345",
+			tagKey:    MockCapiClusterTag,
+			tagValue:  "owned",
 			expectErr: false,
 		},
 	}
@@ -37,7 +47,7 @@ func TestAWSClient_FilterClusterNodeSecurityGroupsByDefaultTags(t *testing.T) {
 	client := NewMockedAwsClient()
 
 	for _, test := range tests {
-		_, err := client.FilterClusterNodeSecurityGroupsByDefaultTags(context.TODO(), test.tagKey)
+		_, err := client.FilterClusterNodeSecurityGroupsByDefaultTags(context.TODO(), test.infraName)
 		if test.expectErr {
 			assert.Error(t, err)
 		} else {
@@ -53,7 +63,7 @@ func TestAWSClient_FilterSecurityGroupByDefaultTags(t *testing.T) {
 		expectErr bool
 	}{
 		{
-			tagKey:    MockClusterTag,
+			tagKey:    MockLegacyClusterTag,
 			nameTag:   MockSecurityGroupId,
 			expectErr: false,
 		},
@@ -98,7 +108,7 @@ func TestAWSClient_FilterSecurityGroupById(t *testing.T) {
 func TestAWSClient_CreateDeleteSecurityGroup(t *testing.T) {
 	client := NewMockedAwsClient()
 
-	resp, err := client.CreateSecurityGroup(context.TODO(), "name", MockVpcId, MockClusterTag)
+	resp, err := client.CreateSecurityGroup(context.TODO(), "name", MockVpcId, MockLegacyClusterTag)
 	assert.NoError(t, err)
 
 	_, err = client.DeleteSecurityGroup(context.TODO(), *resp.GroupId)

--- a/pkg/aws_client/subnet_test.go
+++ b/pkg/aws_client/subnet_test.go
@@ -27,7 +27,7 @@ func TestAWSClient_DescribeSubnets(t *testing.T) {
 		expectErr  bool
 	}{
 		{
-			clusterTag: MockClusterTag,
+			clusterTag: MockLegacyClusterTag,
 			expectErr:  false,
 		},
 		{

--- a/pkg/aws_client/vpc_endpoint_test.go
+++ b/pkg/aws_client/vpc_endpoint_test.go
@@ -87,14 +87,14 @@ func TestAWSClient_DescribeSingleVPCEndpointById(t *testing.T) {
 func TestAWSClient_FilterVPCEndpointByDefaultTags(t *testing.T) {
 	client := NewMockedAwsClient()
 
-	_, err := client.FilterVPCEndpointByDefaultTags(context.TODO(), MockClusterTag, MockClusterNameTag)
+	_, err := client.FilterVPCEndpointByDefaultTags(context.TODO(), MockLegacyClusterTag, MockClusterNameTag)
 	assert.NoError(t, err)
 }
 
 func TestCreateDeleteVPCEndpoint(t *testing.T) {
 	client := NewMockedAwsClient()
 
-	resp, err := client.CreateDefaultInterfaceVPCEndpoint(context.TODO(), "name", MockVpcId, MockVpcEndpointServiceName, MockClusterTag)
+	resp, err := client.CreateDefaultInterfaceVPCEndpoint(context.TODO(), "name", MockVpcId, MockVpcEndpointServiceName, MockLegacyClusterTag)
 	assert.NoError(t, err)
 
 	_, err = client.DeleteVPCEndpoint(context.TODO(), *resp.VpcEndpoint.VpcEndpointId)

--- a/pkg/util/naming.go
+++ b/pkg/util/naming.go
@@ -31,6 +31,8 @@ const (
 	RedHatManagedTagKey      = "red-hat-managed"
 	RedHatManagedTagValue    = "true"
 	SecurityGroupDescription = "Managed by AWS VPCE Operator"
+	LegacyClusterTagPrefix   = "kubernetes.io/cluster"
+	CapiClusterTagPrefix     = "sigs.k8s.io/cluster-api-provider-aws/cluster"
 )
 
 // These are the expected security group suffixes available in the VPC based on the cluster's infra id.
@@ -80,13 +82,22 @@ func GenerateAwsTagsAsMap(name, clusterTagKey string) (map[string]string, error)
 	return tagsMap, nil
 }
 
-// GetClusterTagKey returns the tag assigned to all AWS resources for the given cluster
-func GetClusterTagKey(infraName string) (string, error) {
+// GetClusterLegacyTagKey returns the tag assigned to all AWS resources for the given cluster
+func GetClusterLegacyTagKey(infraName string) (string, error) {
 	if infraName == "" {
-		return "", errors.New("failed to GetClusterTagKey: infraName must be specified")
+		return "", errors.New("failed to GetClusterLegacyTagKey: infraName must be specified")
 	}
 
-	return fmt.Sprintf("kubernetes.io/cluster/%s", infraName), nil
+	return fmt.Sprintf("%s/%s", LegacyClusterTagPrefix, infraName), nil
+}
+
+// GetClusterCapiTagKey returns the tag assigned to all AWS resources for the given cluster in CAPI format
+func GetClusterCapiTagKey(infraName string) (string, error) {
+	if infraName == "" {
+		return "", errors.New("failed to GetClusterCapiTagKey: infraName must be specified")
+	}
+
+	return fmt.Sprintf("%s/%s", CapiClusterTagPrefix, infraName), nil
 }
 
 // GenerateSecurityGroupName generates a name for a security group given a cluster name

--- a/pkg/util/naming_test.go
+++ b/pkg/util/naming_test.go
@@ -37,7 +37,7 @@ func TestGenerateAwsTags(t *testing.T) {
 		},
 		{
 			name:          "cluster",
-			clusterTagKey: "kubernetes.io/cluster/infra",
+			clusterTagKey: LegacyClusterTagPrefix + "/infra",
 			expectErr:     false,
 		},
 	}
@@ -66,12 +66,12 @@ func TestGenerateAwsTagsAsMap(t *testing.T) {
 		},
 		{
 			name:          "cluster",
-			clusterTagKey: "kubernetes.io/cluster/infra",
+			clusterTagKey: LegacyClusterTagPrefix + "/mock-12345",
 			expectErr:     false,
 			expected: map[string]string{
-				"Name":                        "cluster",
-				"kubernetes.io/cluster/infra": "owned",
-				OperatorTagKey:                OperatorTagValue,
+				"Name":                                 "cluster",
+				LegacyClusterTagPrefix + "/mock-12345": "owned",
+				OperatorTagKey:                         OperatorTagValue,
 			},
 		},
 	}
@@ -91,7 +91,7 @@ func TestGenerateAwsTagsAsMap(t *testing.T) {
 	}
 }
 
-func TestGetClusterTagKey(t *testing.T) {
+func TestGetClusterLegacyTagKey(t *testing.T) {
 	tests := []struct {
 		infraName string
 		expected  string
@@ -102,14 +102,42 @@ func TestGetClusterTagKey(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			infraName: "infra",
-			expected:  "kubernetes.io/cluster/infra",
+			infraName: "mock-12345",
+			expected:  LegacyClusterTagPrefix + "/mock-12345",
 			expectErr: false,
 		},
 	}
 
 	for _, test := range tests {
-		actual, err := GetClusterTagKey(test.infraName)
+		actual, err := GetClusterLegacyTagKey(test.infraName)
+		if test.expectErr {
+			assert.NotNil(t, err)
+		} else {
+			assert.Nil(t, err)
+			assert.Equal(t, test.expected, actual)
+		}
+	}
+}
+
+func TestGetClusterCapiTagKey(t *testing.T) {
+	tests := []struct {
+		infraName string
+		expected  string
+		expectErr bool
+	}{
+		{
+			infraName: "",
+			expectErr: true,
+		},
+		{
+			infraName: "mock-12345",
+			expected:  CapiClusterTagPrefix + "/mock-12345",
+			expectErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		actual, err := GetClusterCapiTagKey(test.infraName)
 		if test.expectErr {
 			assert.NotNil(t, err)
 		} else {


### PR DESCRIPTION
Introduced in 4.16 was a CAPI change in the aws tag key naming format. From `kubernetes.io/cluster/${infraID}` to `sigs.k8s.io/cluster-api-provider-aws/cluster/${infraID}`.
This change supports both the old ("legacy") format while also supporting the new CAPI naming scheme. This also adds additional logging and unit testing.

Fixes [OSD-29372](https://issues.redhat.com//browse/OSD-29372)