### PR TITLE
OSD-29372 Fix tag-key values for DescribeSecurityGroups

### DIFF
--- a/controllers/vpcendpoint/helpers.go
+++ b/controllers/vpcendpoint/helpers.go
@@ -356,7 +356,7 @@ func (r *VpcEndpointReconciler) generateMissingSecurityGroupRules(ctx context.Co
 	}
 
 	if len(sourceSgIds) == 0 {
-		r.log.V(1).Info("Unable to find source security groups")
+		return nil, nil, fmt.Errorf("failed to find source security groups by default tags")
 	}
 
 	// Ensure ingress/egress rules

--- a/pkg/aws_client/security_group.go
+++ b/pkg/aws_client/security_group.go
@@ -52,11 +52,7 @@ func (c *AWSClient) FilterClusterNodeSecurityGroupsByDefaultTags(ctx context.Con
 		Filters: []types.Filter{
 			{
 				Name:   aws.String("tag-key"),
-				Values: []string{clusterLegacyTag},
-			},
-			{
-				Name:   aws.String("tag-key"),
-				Values: []string{clusterCapiTag},
+				Values: []string{clusterLegacyTag, clusterCapiTag},
 			},
 			{
 				Name:   aws.String("tag:Name"),


### PR DESCRIPTION
This fixes the usage of tag-key values for DescribeSecurityGroups call such that any combination of key will work. This also adds additional error returns upon unable to find the source SGs.

Tested locally against a problematic cluster.

Fixes [OSD-29372](https://issues.redhat.com//browse/OSD-29372)