### PR TITLE
OSD-29407: Add back log and remove early return for zero sg founds

### DIFF
--- a/controllers/vpcendpoint/helpers.go
+++ b/controllers/vpcendpoint/helpers.go
@@ -356,7 +356,7 @@ func (r *VpcEndpointReconciler) generateMissingSecurityGroupRules(ctx context.Co
 	}
 
 	if len(sourceSgIds) == 0 {
-		return nil, nil, fmt.Errorf("failed to find source security groups by default tags")
+		r.log.V(1).Info("Unable to find source security groups")
 	}
 
 	// Ensure ingress/egress rules


### PR DESCRIPTION
In https://github.com/openshift/aws-vpce-operator/pull/143 we added some better handling for when no security groups were found in TGW account that match the filter.

Then in https://github.com/openshift/aws-vpce-operator/commit/2e85fc6e65ca0eb15b5b51caa682383faf41d6ec we added the return and error back, but now we are realizing we were implicitly relying on this "log and continue".

Add this back to fix that.