### PR TITLE
SREP-148: Ensure aws-vpce-operator is logging at verbosity 0

### DIFF
--- a/controllers/vpcendpoint/validation.go
+++ b/controllers/vpcendpoint/validation.go
@@ -76,7 +76,7 @@ func (r *VpcEndpointReconciler) validateSecurityGroup(ctx context.Context, resou
 
 	// Not idempotent
 	if _, err := r.awsClient.AuthorizeSecurityGroupRules(ctx, ingressInput, egressInput); err != nil {
-		r.log.V(1).Error(err, "failed to authorize security group rules")
+		r.log.V(0).Error(err, "failed to authorize security group rules")
 		return err
 	}
 


### PR DESCRIPTION
aws-vpce-operator was found to have many places in code where we log to verbosity 1 for errors, which causes them to not render to stdout and therefore are not found in Dynatrace.