### PR TITLE
SREP-87: Enable TechPreviewUnsafeFailForward for FedRAMP specific OperatorGroup

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN make go-build
 
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1255
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1295
 
 ENV USER_UID=1001 \
     USER_NAME=aws-vpce-operator

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1255
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1295
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/config/config.go
+++ b/config/config.go
@@ -17,8 +17,7 @@ limitations under the License.
 package config
 
 const (
-	OperatorName      string = "aws-vpce-operator"
-	OperatorNamespace string = "openshift-aws-vpce-operator"
-
+	OperatorName       = "aws-vpce-operator"
+	OperatorNamespace  = "openshift-aws-vpce-operator"
 	EnableOLMSkipRange = "true"
 )

--- a/hack/olm-registry/olm-artifacts-template-fedramp.yaml
+++ b/hack/olm-registry/olm-artifacts-template-fedramp.yaml
@@ -96,6 +96,7 @@ objects:
   spec:
     targetNamespaces:
     - openshift-${REPO_NAME}
+    upgradeStrategy: TechPreviewUnsafeFailForward
 - apiVersion: operators.coreos.com/v1alpha1
   kind: Subscription
   metadata:


### PR DESCRIPTION
As part of [SREP-87](https://issues.redhat.com/browse/SREP-87), we need to ensure a few settings are changed on operators to ensure they promote healthily. All those settings were already defined for this project, with the exception of `TechPreviewUnsafeFailForward` on the FedRAMP OperatorGroup. This sets that to line up with commercial.