### PR TITLE
OSD-30761: Adding Renovate and on-cel expression , konflux build files changes

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>openshift/boilerplate//.github/renovate.json"
+  ]
+}

--- a/.tekton/aws-vpce-operator-pull-request.yaml
+++ b/.tekton/aws-vpce-operator-pull-request.yaml
@@ -8,8 +8,13 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request" 
+      && target_branch == "main"
+      && ("**/*.go".pathChanged() ||
+          "**/go.*".pathChanged() ||
+          "build/Dockerfile".pathChanged() ||
+          ".tekton/aws-vpce-operator-pull-request.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: aws-vpce-operator

--- a/.tekton/aws-vpce-operator-push.yaml
+++ b/.tekton/aws-vpce-operator-push.yaml
@@ -7,8 +7,13 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" 
+      && target_branch == "main"
+      && ("**/*.go".pathChanged() ||
+          "**/go.*".pathChanged() ||
+          "build/Dockerfile".pathChanged() ||
+          ".tekton/aws-vpce-operator-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: aws-vpce-operator


### PR DESCRIPTION
Adding Konflux .tekton pipelines for push and pull events
Adding Konflux .tekton build trigger expression
Adding renovate config file that is configured to auto merge bumps to the .tekton pipelines (Konflux build)


Steps To Manually Test
Make sure the automated PR's created(open state) for .tekton pipelines (Konflux build)
verify the image released under konflux
https://konflux-ui.apps.kflux-prd-rh03.nnv1.p1.openshiftapps.com/ns/aws-vpce-operator-tenant/applications/aws-vpce-operator/releases


https://issues.redhat.com/browse/OSD-30761