### PR TITLE
Bump Go down to 1.24.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/aws-vpce-operator
 
-go 1.24.4
+go 1.24.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.26.1


### PR DESCRIPTION
Bump Go down to 1.24.0 to resolve Jenkins [build](https://ci.int.devshift.net/job/openshift-aws-vpce-operator-gh-build-main/384/console) failures.