### PR TITLE
SREP-1321: Added missing steps to running the Operator on ROSA STS clusters

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN make go-build
 
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1754327153
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1754584681
 
 ENV USER_UID=1001 \
     USER_NAME=aws-vpce-operator

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1754327153
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1754584681
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/deploy/40_namespace.yaml
+++ b/deploy/40_namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-aws-vpce-operator

--- a/dev/README.md
+++ b/dev/README.md
@@ -117,11 +117,31 @@ run locally (i.e. with `go run .`) and depends on local K8s and AWS credentials 
 ## Running in a ROSA STS cluster
 
 1. Build and push a container image for the operator (or use an existing image from [quay.io/app-sre/aws-vpce-operator](https://quay.io/repository/app-sre/aws-vpce-operator?tab=tags)).
+
 2. Update the container image in `./deploy/20_operator.yml`
-3. Apply all the resources (namespace, RBAC, deployment) to the cluster
+
+3. Create a secret with your AWS credentials
+    ```yaml
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: avo-aws-iam-user-creds
+      namespace: openshift-aws-vpce-operator
+    type: Opaque
+    data:
+      aws_secret_access_key: <base64 $AWS_ACCESS_KEY_ID>
+      aws_access_key_id: <base64 $AWS_SECRET_ACCESS_KEY>
+    ```
+
+4. Apply all the resources (namespace, RBAC, deployment) to the cluster.
 
     ```bash
     oc apply -f deploy
+    ```
+
+5. Apply all the CRDs on deploy/crds/
+    ```bash
+    oc apply -f deploy/crds/
     ```
 
 ## Profit

--- a/dev/vpce_example.yml
+++ b/dev/vpce_example.yml
@@ -1,9 +1,4 @@
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: openshift-aws-vpce-operator
----
 apiVersion: avo.openshift.io/v1alpha2
 kind: VpcEndpoint
 metadata:


### PR DESCRIPTION
Made the documentation a bit cleared and added steps that are necessary in order to successfully run the operator on a ROSA STS clusters. This credentials on the CR are described as optional, but are actually necessary for the operator.