### PR TITLE
Fix CEL validation rule allowing VpcEndpoints without a service name

### DIFF
--- a/api/v1alpha2/vpcendpoint_types.go
+++ b/api/v1alpha2/vpcendpoint_types.go
@@ -232,7 +232,7 @@ type AwsEndpointSelector struct {
 
 // +kubebuilder:validation:XValidation:message=.spec.vpc.autoDiscoverSubnets is not supported with .spec.region,rule=!(has(self.region) && self.vpc.autoDiscoverSubnets)
 // +kubebuilder:validation:XValidation:message=.spec.customDns.route53PrivateHostedZone.autoDiscoverPrivateHostedZone is not supported with .spec.region,rule=!(has(self.region) && self.customDns.route53PrivateHostedZone.autoDiscoverPrivateHostedZone)
-// +kubebuilder:validation:XValidation:message="one of .spec.serviceName, .spec.serviceNameRef.name, or .spec.serviceNameRef.valueFrom.awsEndpointServiceRef.name must be specified",rule=has(self.serviceName) || (has(self.serviceNameRef) && has(self.serviceNameRef.name)) || (!has(self.serviceNameRef.valueFrom) || !has(self.serviceNameRef.valueFrom.awsEndpointServiceRef) || has(self.serviceNameRef.valueFrom.awsEndpointServiceRef.name))
+// +kubebuilder:validation:XValidation:message="one of .spec.serviceName, .spec.serviceNameRef.name, or .spec.serviceNameRef.valueFrom.awsEndpointServiceRef.name must be specified",rule=has(self.serviceName) || (has(self.serviceNameRef) && (has(self.serviceNameRef.name) || (has(self.serviceNameRef.valueFrom) && has(self.serviceNameRef.valueFrom.awsEndpointServiceRef))))
 
 // VpcEndpointSpec defines the desired state of VpcEndpoint
 type VpcEndpointSpec struct {

--- a/api/v1alpha2/vpcendpoint_types.go
+++ b/api/v1alpha2/vpcendpoint_types.go
@@ -232,6 +232,16 @@ type AwsEndpointSelector struct {
 
 // +kubebuilder:validation:XValidation:message=.spec.vpc.autoDiscoverSubnets is not supported with .spec.region,rule=!(has(self.region) && self.vpc.autoDiscoverSubnets)
 // +kubebuilder:validation:XValidation:message=.spec.customDns.route53PrivateHostedZone.autoDiscoverPrivateHostedZone is not supported with .spec.region,rule=!(has(self.region) && self.customDns.route53PrivateHostedZone.autoDiscoverPrivateHostedZone)
+//
+// A VpcEndpoint must reference a VPC Endpoint Service via exactly one of:
+//  1. .spec.serviceName (direct service name string)
+//  2. .spec.serviceNameRef.name (named reference)
+//  3. .spec.serviceNameRef.valueFrom.awsEndpointServiceRef (lookup from an AwsEndpointService resource)
+//
+// The CEL rule below enforces this by requiring at least one of these paths to be present.
+// IMPORTANT: All branches must use positive assertions (has()), not negations (!has()). Using
+// !has() on a child of an absent optional parent returns true, which can silently bypass the rule.
+//
 // +kubebuilder:validation:XValidation:message="one of .spec.serviceName, .spec.serviceNameRef.name, or .spec.serviceNameRef.valueFrom.awsEndpointServiceRef.name must be specified",rule=has(self.serviceName) || (has(self.serviceNameRef) && (has(self.serviceNameRef.name) || (has(self.serviceNameRef.valueFrom) && has(self.serviceNameRef.valueFrom.awsEndpointServiceRef))))
 
 // VpcEndpointSpec defines the desired state of VpcEndpoint

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN make go-build
 
 ###
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1771346502
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1773939694
 
 ENV USER_UID=1001 \
     USER_NAME=aws-vpce-operator

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1771346502
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1773939694
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/deploy/crds/avo.openshift.io_vpcendpoints.yaml
+++ b/deploy/crds/avo.openshift.io_vpcendpoints.yaml
@@ -610,9 +610,8 @@ spec:
               rule: '!(has(self.region) && self.customDns.route53PrivateHostedZone.autoDiscoverPrivateHostedZone)'
             - message: one of .spec.serviceName, .spec.serviceNameRef.name, or .spec.serviceNameRef.valueFrom.awsEndpointServiceRef.name
                 must be specified
-              rule: has(self.serviceName) || (has(self.serviceNameRef) && has(self.serviceNameRef.name))
-                || (!has(self.serviceNameRef.valueFrom) || !has(self.serviceNameRef.valueFrom.awsEndpointServiceRef)
-                || has(self.serviceNameRef.valueFrom.awsEndpointServiceRef.name))
+              rule: has(self.serviceName) || (has(self.serviceNameRef) && (has(self.serviceNameRef.name)
+                || (has(self.serviceNameRef.valueFrom) && has(self.serviceNameRef.valueFrom.awsEndpointServiceRef))))
           status:
             description: VpcEndpointStatus defines the observed state of VpcEndpoint
             properties:

--- a/deploy/crds/avo.openshift.io_vpcendpointtemplates.yaml
+++ b/deploy/crds/avo.openshift.io_vpcendpointtemplates.yaml
@@ -484,9 +484,8 @@ spec:
                         or .spec.serviceNameRef.valueFrom.awsEndpointServiceRef.name
                         must be specified
                       rule: has(self.serviceName) || (has(self.serviceNameRef) &&
-                        has(self.serviceNameRef.name)) || (!has(self.serviceNameRef.valueFrom)
-                        || !has(self.serviceNameRef.valueFrom.awsEndpointServiceRef)
-                        || has(self.serviceNameRef.valueFrom.awsEndpointServiceRef.name))
+                        (has(self.serviceNameRef.name) || (has(self.serviceNameRef.valueFrom)
+                        && has(self.serviceNameRef.valueFrom.awsEndpointServiceRef))))
                 required:
                 - spec
                 type: object

--- a/deploy_pko/CustomResourceDefinition-vpcendpoints.avo.openshift.io.yaml
+++ b/deploy_pko/CustomResourceDefinition-vpcendpoints.avo.openshift.io.yaml
@@ -704,9 +704,8 @@ spec:
               rule: '!(has(self.region) && self.customDns.route53PrivateHostedZone.autoDiscoverPrivateHostedZone)'
             - message: one of .spec.serviceName, .spec.serviceNameRef.name, or .spec.serviceNameRef.valueFrom.awsEndpointServiceRef.name
                 must be specified
-              rule: has(self.serviceName) || (has(self.serviceNameRef) && has(self.serviceNameRef.name))
-                || (!has(self.serviceNameRef.valueFrom) || !has(self.serviceNameRef.valueFrom.awsEndpointServiceRef)
-                || has(self.serviceNameRef.valueFrom.awsEndpointServiceRef.name))
+              rule: has(self.serviceName) || (has(self.serviceNameRef) && (has(self.serviceNameRef.name)
+                || (has(self.serviceNameRef.valueFrom) && has(self.serviceNameRef.valueFrom.awsEndpointServiceRef))))
           status:
             description: VpcEndpointStatus defines the observed state of VpcEndpoint
             properties:

--- a/deploy_pko/CustomResourceDefinition-vpcendpointtemplates.avo.openshift.io.yaml
+++ b/deploy_pko/CustomResourceDefinition-vpcendpointtemplates.avo.openshift.io.yaml
@@ -582,9 +582,8 @@ spec:
                         or .spec.serviceNameRef.valueFrom.awsEndpointServiceRef.name
                         must be specified
                       rule: has(self.serviceName) || (has(self.serviceNameRef) &&
-                        has(self.serviceNameRef.name)) || (!has(self.serviceNameRef.valueFrom)
-                        || !has(self.serviceNameRef.valueFrom.awsEndpointServiceRef)
-                        || has(self.serviceNameRef.valueFrom.awsEndpointServiceRef.name))
+                        (has(self.serviceNameRef.name) || (has(self.serviceNameRef.valueFrom)
+                        && has(self.serviceNameRef.valueFrom.awsEndpointServiceRef))))
                 required:
                 - spec
                 type: object


### PR DESCRIPTION
## Summary

- Fix broken CEL validation rule that allowed creating VpcEndpoints without referencing a VPC Endpoint Service
- The rule was incorrectly refactored in d376a13 to use `has()` instead of `== ""` comparisons. The third disjunct `!has(self.serviceNameRef.valueFrom)` always evaluates to `true` when `serviceNameRef` is absent (because `!has()` on a child of an absent optional parent returns `true`), causing the entire rule to pass unconditionally
- Rewrite the rule as a positive assertion and add documentation explaining the rule and the `!has()` pitfall to prevent future regressions

## Test plan

- [x] Existing e2e test at `test/e2e/aws_vpce_operator_tests.go:155` ("rejects VpcEndpoints that do not reference a VPC Endpoint Service") should now pass
- [x] Existing e2e test at `test/e2e/aws_vpce_operator_tests.go:130` ("accepts a valid VpcEndpoint with .spec.serviceName") should continue to pass
- [x] VpcEndpoints with `serviceNameRef.name` or `serviceNameRef.valueFrom.awsEndpointServiceRef` should still be accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

PS: In order to pass tests this PR has been rebased onto #369 to include the image change.