### PR TITLE
Fix e2e CRD apply to update existing CRDs

### DIFF
--- a/test/e2e/aws_vpce_operator_tests.go
+++ b/test/e2e/aws_vpce_operator_tests.go
@@ -262,8 +262,18 @@ func applyCRDYaml(ctx context.Context, c client.Client, yaml []byte) (*apiextens
 	}
 
 	crd := obj.(*apiextensionsv1.CustomResourceDefinition)
-	if err := c.Create(ctx, crd); err != nil && !kerr.IsAlreadyExists(err) {
-		return nil, fmt.Errorf("failed to apply CRD: %v", err)
+	if err := c.Create(ctx, crd); err != nil {
+		if !kerr.IsAlreadyExists(err) {
+			return nil, fmt.Errorf("failed to create CRD: %v", err)
+		}
+		existing := &apiextensionsv1.CustomResourceDefinition{}
+		if err := c.Get(ctx, client.ObjectKeyFromObject(crd), existing); err != nil {
+			return nil, fmt.Errorf("failed to get existing CRD: %v", err)
+		}
+		crd.ResourceVersion = existing.ResourceVersion
+		if err := c.Update(ctx, crd); err != nil {
+			return nil, fmt.Errorf("failed to update CRD: %v", err)
+		}
 	}
 
 	// Wait for CRDs to appear in discovery, otherwise you can get responses from the API server like:


### PR DESCRIPTION
## Summary
- When `applyCRDYaml` encountered an existing CRD, it silently skipped the create and left the old CRD in place
- This caused e2e tests to run on stale CRDs when re-running against existing clusters, leading to false failures (e.g. missing CEL validation rules)
- Updated to fetch and update the existing CRD when create returns AlreadyExists

## Test plan
- [x] Run e2e tests against a cluster that already has the old CRDs installed
- [x] Verify the CEL validation test passes after the CRD is updated in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)