### PR TITLE
SREP-4341: add CredentialsRequest and AvoConfig SSSs to PKO template

### DIFF
--- a/hack/pko/clusterpackage.yaml
+++ b/hack/pko/clusterpackage.yaml
@@ -50,3 +50,108 @@ objects:
             image: ${PKO_IMAGE}:${IMAGE_TAG}
             config:
               image: ${OPERATOR_IMAGE}:${IMAGE_TAG}
+  ########################
+  # CredentialsRequest SSS
+  ########################
+  - apiVersion: hive.openshift.io/v1
+    kind: SelectorSyncSet
+    metadata:
+      labels:
+        managed.openshift.io/gitHash: ${IMAGE_TAG}
+        managed.openshift.io/gitRepoName: ${REPO_NAME}
+        managed.openshift.io/osd: "true"
+      name: aws-vpce-operator-creds
+    spec:
+      clusterDeploymentSelector:
+        matchExpressions:
+          - key: ext-hypershift.openshift.io/cluster-type
+            operator: In
+            values:
+              - "management-cluster"
+              - "service-cluster"
+          - key: api.openshift.com/fedramp
+            operator: NotIn
+            values: ["true"]
+      resourceApplyMode: Upsert
+      applyBehavior: CreateOrUpdate
+      resources:
+        - apiVersion: cloudcredential.openshift.io/v1
+          kind: CredentialsRequest
+          metadata:
+            name: avo-aws-iam-user-creds
+            namespace: openshift-${REPO_NAME}
+          spec:
+            secretRef:
+              name: avo-aws-iam-user-creds
+              namespace: openshift-${REPO_NAME}
+            providerSpec:
+              apiVersion: cloudcredential.openshift.io/v1
+              kind: AWSProviderSpec
+              statementEntries:
+              - effect: Allow
+                resource: '*'
+                action:
+                # VPCEndpoint Controller
+                - ec2:CreateTags
+                - ec2:DescribeSubnets
+                - ec2:CreateSecurityGroup
+                - ec2:DeleteSecurityGroup
+                - ec2:DescribeSecurityGroups
+                - ec2:AuthorizeSecurityGroupIngress
+                - ec2:AuthorizeSecurityGroupEgress
+                - ec2:DescribeSecurityGroupRules
+                - ec2:CreateVpcEndpoint
+                - ec2:DeleteVpcEndpoints
+                - ec2:DescribeVpcEndpoints
+                - ec2:DescribeVpcs
+                - ec2:ModifyVpcEndpoint
+                - ec2:DescribeVpcEndpointServices
+                - route53:ChangeResourceRecordSets
+                - route53:ListHostedZonesByVPC
+                - route53:ListResourceRecordSets
+                - route53:ListTagsForResource
+                - route53:GetHostedZone
+                - route53:CreateHostedZone
+                - route53:DeleteHostedZone
+                - route53:ChangeTagsForResource
+                - route53:CreateVpcAssociationAuthorization
+                # VPCEndpointAcceptance Controller
+                - sts:AssumeRole
+                - ec2:DescribeVpcEndpointConnections
+                - ec2:AcceptVpcEndpointConnections
+  ############################################
+  # HyperShift Management Cluster Config SSS #
+  ############################################
+  - apiVersion: hive.openshift.io/v1
+    kind: SelectorSyncSet
+    metadata:
+      labels:
+        managed.openshift.io/gitHash: ${IMAGE_TAG}
+        managed.openshift.io/gitRepoName: ${REPO_NAME}
+        managed.openshift.io/osd: "true"
+      name: aws-vpce-operator-mc-config
+    spec:
+      clusterDeploymentSelector:
+        matchExpressions:
+          - key: ext-hypershift.openshift.io/cluster-type
+            operator: In
+            values:
+              - "management-cluster"
+          - key: api.openshift.com/fedramp
+            operator: NotIn
+            values: ["true"]
+      resourceApplyMode: Sync
+      applyBehavior: CreateOrUpdate
+      resources:
+        - kind: ConfigMap
+          apiVersion: v1
+          metadata:
+            name: avo-config
+            namespace: openshift-aws-vpce-operator
+          data:
+            avo_config.yaml: |-
+              apiVersion: avo.openshift.io/v1alpha1
+              kind: AvoConfig
+              enableVpcEndpointController: true
+              enableVpcEndpointAcceptanceController: false
+              enableVpcEndpointTemplateController: true


### PR DESCRIPTION
## Summary
- Adds two new SelectorSyncSets to the PKO ClusterPackage template (`hack/pko/clusterpackage.yaml`) for resources that were orphaned during the OLM-to-PKO migration
- `aws-vpce-operator-creds`: syncs the CredentialsRequest for AWS IAM permissions to MC+SC clusters
- `aws-vpce-operator-mc-config`: syncs the AvoConfig ConfigMap to Management Clusters only
- CredentialsRequest and ConfigMap content are identical to the original OLM template

Jira: https://redhat.atlassian.net/browse/SREP-4341

## Follow-up (app-interface)
After this is deployed and validated:
1. Update the orphaned OLM SSSs on Hives to `Upsert` mode (to avoid deleting the AVO namespace)
2. Remove the old OLM SSSs

## Test plan
- [x] Verify template renders 3 SSSs with correct selectors and resources
- [ ] Deploy to integration and confirm new SSSs appear on Hive
- [ ] Confirm CredentialsRequest and ConfigMap are synced to target clusters
- [ ] Validate operator continues functioning normally