### PR TITLE
Add terminationMessagePolicy, required-scc annotation, and lint fixes

### DIFF
--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the avo v1alpha1 API group
-//+kubebuilder:object:generate=true
-//+groupName=avo.openshift.io
+// +kubebuilder:object:generate=true
+// +groupName=avo.openshift.io
 package v1alpha1
 
 import (

--- a/controllers/vpcendpoint/cleanup.go
+++ b/controllers/vpcendpoint/cleanup.go
@@ -135,7 +135,7 @@ func (r *VpcEndpointReconciler) cleanupAwsResources(ctx context.Context, resourc
 							// Delete all records in the hosted zone except the default SOA and NS records
 							for _, resourceRecord := range listRRSResp.ResourceRecordSets {
 								rr := resourceRecord
-								switch rr.Type {
+								switch rr.Type { //nolint:exhaustive
 								case route53Types.RRTypeNs:
 									continue
 								case route53Types.RRTypeSoa:
@@ -155,7 +155,7 @@ func (r *VpcEndpointReconciler) cleanupAwsResources(ctx context.Context, resourc
 						}
 					} else {
 						// Shouldn't happen
-						return fmt.Errorf("unexpected error while deleting hosted zone: %v", err)
+						return fmt.Errorf("unexpected error while deleting hosted zone: %w", err)
 					}
 				} else {
 					r.log.V(0).Info("Deleted Route53 hosted zone", "hostedZoneId", resource.Status.HostedZoneId)
@@ -184,7 +184,7 @@ func (r *VpcEndpointReconciler) cleanupAwsResources(ctx context.Context, resourc
 				}
 			} else {
 				// Shouldn't happen
-				return fmt.Errorf("unexpected error while deleting VPC Endpoint: %v", err)
+				return fmt.Errorf("unexpected error while deleting VPC Endpoint: %w", err)
 			}
 		} else {
 			r.Recorder.Eventf(resource, corev1.EventTypeNormal, "Deleted", "Deleted VPC endpoint: %s", vpceId)
@@ -216,7 +216,7 @@ func (r *VpcEndpointReconciler) cleanupAwsResources(ctx context.Context, resourc
 				}
 			} else {
 				// Shouldn't happen
-				return fmt.Errorf("unexpected error while deleting security group: %v", err)
+				return fmt.Errorf("unexpected error while deleting security group: %w", err)
 			}
 		} else {
 			r.Recorder.Eventf(resource, corev1.EventTypeNormal, "Deleted", "Deleted security group: %s", sgId)

--- a/controllers/vpcendpoint/helpers.go
+++ b/controllers/vpcendpoint/helpers.go
@@ -62,7 +62,7 @@ func (r *VpcEndpointReconciler) parseClusterInfo(ctx context.Context, vpce *avov
 			r.log.V(1).Info("Found infrastructure name:", "name", vpce.Status.InfraId)
 			vpce.Status.InfraId = infraName
 			if err := r.Status().Update(ctx, vpce); err != nil {
-				return fmt.Errorf("failed to update status: %v", err)
+				return fmt.Errorf("failed to update status: %w", err)
 			}
 		}
 	} else {
@@ -75,7 +75,7 @@ func (r *VpcEndpointReconciler) parseClusterInfo(ctx context.Context, vpce *avov
 			r.log.V(1).Info("Found infrastructure name:", "name", vpce.Status.InfraId)
 			vpce.Status.InfraId = infraName
 			if err := r.Status().Update(ctx, vpce); err != nil {
-				return fmt.Errorf("failed to update status: %v", err)
+				return fmt.Errorf("failed to update status: %w", err)
 			}
 		}
 	}
@@ -174,7 +174,7 @@ func (r *VpcEndpointReconciler) parseClusterInfo(ctx context.Context, vpce *avov
 
 		vpce.Status.VPCId = vpcId
 		if err := r.Status().Update(ctx, vpce); err != nil {
-			return fmt.Errorf("failed to update status: %v", err)
+			return fmt.Errorf("failed to update status: %w", err)
 		}
 	}
 
@@ -227,7 +227,7 @@ func (r *VpcEndpointReconciler) getVpcEndpointServiceName(ctx context.Context, v
 
 	vpce.Status.VPCEndpointServiceName = vpceServiceName
 	if err := r.Status().Update(ctx, vpce); err != nil {
-		return fmt.Errorf("failed to update status: %v", err)
+		return fmt.Errorf("failed to update status: %w", err)
 	}
 
 	return nil
@@ -303,7 +303,7 @@ func (r *VpcEndpointReconciler) findOrCreateSecurityGroup(ctx context.Context, r
 func (r *VpcEndpointReconciler) createMissingSecurityGroupTags(ctx context.Context, sg *ec2Types.SecurityGroup, resource *avov1alpha2.VpcEndpoint) error {
 	sgName, err := util.GenerateSecurityGroupName(resource.Status.InfraId, resource.Name)
 	if err != nil {
-		return fmt.Errorf("failed to generate security group name: %v", err)
+		return fmt.Errorf("failed to generate security group name: %w", err)
 	}
 
 	defaultTagsMap, err := util.GenerateAwsTagsAsMap(sgName, r.clusterInfo.clusterTag)
@@ -316,7 +316,7 @@ func (r *VpcEndpointReconciler) createMissingSecurityGroupTags(ctx context.Conte
 		r.log.V(1).Info("Adding missing security group tags")
 		defaultTags, err := util.GenerateAwsTags(sgName, r.clusterInfo.clusterTag)
 		if err != nil {
-			return fmt.Errorf("failed to generate expected tags: %v", err)
+			return fmt.Errorf("failed to generate expected tags: %w", err)
 		}
 		if _, err := r.awsClient.CreateTags(ctx, &ec2.CreateTagsInput{
 			Resources: []string{*sg.GroupId},
@@ -763,10 +763,7 @@ func (r *VpcEndpointReconciler) ensureVpcEndpointSubnets(ctx context.Context, vp
 // ensureVpcEndpointSecurityGroups ensures that the security group associated with the VPC Endpoint
 // is only the expected one.
 func (r *VpcEndpointReconciler) ensureVpcEndpointSecurityGroups(ctx context.Context, vpce *ec2Types.VpcEndpoint, resource *avov1alpha2.VpcEndpoint) error {
-	sgToAdd, sgToRemove, err := r.diffVpcEndpointSecurityGroups(vpce, resource)
-	if err != nil {
-		return err
-	}
+	sgToAdd, sgToRemove := r.diffVpcEndpointSecurityGroups(vpce, resource)
 
 	if len(sgToAdd) > 0 {
 		r.log.V(1).Info("Adding security group(s) to VPC Endpoint", "sgToAdd", sgToAdd)
@@ -794,7 +791,7 @@ func (r *VpcEndpointReconciler) ensureVpcEndpointSecurityGroups(ctx context.Cont
 // diffVpcEndpointSecurityGroups compares the security groups associated with the VPC Endpoint with
 // the security group ID recorded in the resource's status, returning security groups that need to be added
 // and security groups that need to be removed from the VPC Endpoint.
-func (r *VpcEndpointReconciler) diffVpcEndpointSecurityGroups(vpce *ec2Types.VpcEndpoint, resource *avov1alpha2.VpcEndpoint) ([]string, []string, error) {
+func (r *VpcEndpointReconciler) diffVpcEndpointSecurityGroups(vpce *ec2Types.VpcEndpoint, resource *avov1alpha2.VpcEndpoint) ([]string, []string) {
 	vpceSgIds := make([]string, len(vpce.Groups))
 	for i := range vpce.Groups {
 		vpceSgIds[i] = *vpce.Groups[i].GroupId
@@ -805,7 +802,7 @@ func (r *VpcEndpointReconciler) diffVpcEndpointSecurityGroups(vpce *ec2Types.Vpc
 		[]string{resource.Status.SecurityGroupId},
 	)
 
-	return sgToAdd, sgToRemove, nil
+	return sgToAdd, sgToRemove
 }
 
 // findOrCreatePrivateHostedZone ensures the existence of a Route53 Private Hosted Zone given a custom domain name
@@ -918,7 +915,7 @@ func (r *VpcEndpointReconciler) generateRoute53Record(ctx context.Context, resou
 
 	// VPCEndpoint doesn't exist anymore for some reason
 	if vpceResp == nil || len(vpceResp.VpcEndpoints) == 0 {
-		return nil, nil
+		return nil, nil //nolint:nilnil
 	}
 
 	// DNSEntries won't be populated until the state is available
@@ -929,7 +926,7 @@ func (r *VpcEndpointReconciler) generateRoute53Record(ctx context.Context, resou
 	if len(vpceResp.VpcEndpoints[0].DnsEntries) == 0 {
 		if !resource.DeletionTimestamp.IsZero() {
 			// When we're deleting the VPC Endpoint, handle the edge case where it doesn't have any subnets attached anymore
-			return nil, nil
+			return nil, nil //nolint:nilnil
 		}
 
 		return nil, fmt.Errorf("VPCEndpoint has no DNS entries")

--- a/controllers/vpcendpoint/helpers_test.go
+++ b/controllers/vpcendpoint/helpers_test.go
@@ -569,9 +569,8 @@ func TestVpcEndpointReconciler_diffVpcEndpointSecurityGroups(t *testing.T) {
 			clusterInfo: nil,
 		}
 		t.Run(test.name, func(t *testing.T) {
-			actualToAdd, actualToRemove, err := r.diffVpcEndpointSecurityGroups(test.vpce, test.resource)
+			actualToAdd, actualToRemove := r.diffVpcEndpointSecurityGroups(test.vpce, test.resource)
 
-			assert.NoError(t, err)
 			assert.Equalf(t, test.expectedNumToAdd, len(actualToAdd), "expected to add %d, got %d", test.expectedNumToAdd, len(actualToAdd))
 			assert.Equalf(t, test.expectedNumToRemove, len(actualToRemove), "expected to remove %d, got %d", test.expectedNumToRemove, len(actualToRemove))
 		})

--- a/controllers/vpcendpoint/validation.go
+++ b/controllers/vpcendpoint/validation.go
@@ -118,7 +118,7 @@ func (r *VpcEndpointReconciler) validateVPCEndpoint(ctx context.Context, resourc
 
 	// When this bug is fixed we can switch/case off of enums
 	// https://github.com/aws/aws-sdk/issues/116
-	switch vpce.State {
+	switch vpce.State { //nolint:exhaustive
 	case "pendingAcceptance":
 		vpcePendingAcceptance.WithLabelValues(resource.Name, resource.Namespace, resource.Status.VPCEndpointId).Set(1)
 		// Nothing we can do at the moment, the VPC Endpoint needs to be accepted
@@ -376,6 +376,10 @@ func (r *VpcEndpointReconciler) validateR53HostedZoneRecord(ctx context.Context,
 	resourceRecord, err := r.generateRoute53Record(ctx, resource)
 	if err != nil {
 		r.log.V(0).Info("Skipping Route53 Record", "error", err.Error())
+		return nil
+	}
+	if resourceRecord == nil {
+		r.log.V(0).Info("Skipping Route53 Record: no resource record available")
 		return nil
 	}
 

--- a/controllers/vpcendpointtemplate/vpcendpointtemplate_controller.go
+++ b/controllers/vpcendpointtemplate/vpcendpointtemplate_controller.go
@@ -242,7 +242,7 @@ type enquerequestForControlplane struct {
 	Client client.Client
 }
 
-func (e *enquerequestForControlplane) mapAndEnqueue(ctx context.Context, q workqueue.RateLimitingInterface, obj client.Object, reqs map[reconcile.Request]struct{}) {
+func (e *enquerequestForControlplane) mapAndEnqueue(ctx context.Context, q workqueue.RateLimitingInterface, _ client.Object, reqs map[reconcile.Request]struct{}) {
 	// TODO: We're currently not filtering this by only Private HostedControlPlanes, so it costs us approximately $87/year/VpcEndpoint
 	// Ref: https://aws.amazon.com/privatelink/pricing/
 	matches := []reconcile.Request{}

--- a/deploy/20_operator.yaml
+++ b/deploy/20_operator.yaml
@@ -12,6 +12,8 @@ spec:
     metadata:
       labels:
         name: aws-vpce-operator
+      annotations:
+        openshift.io/required-scc: restricted-v2
     spec:
       serviceAccountName: aws-vpce-operator
       securityContext:
@@ -78,6 +80,7 @@ spec:
             periodSeconds: 10
           securityContext:
             allowPrivilegeEscalation: false
+          terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - name: openshift-sa-token
               mountPath: "/var/run/secrets/openshift/serviceaccount"

--- a/deploy_pko/Deployment-aws-vpce-operator.yaml.gotmpl
+++ b/deploy_pko/Deployment-aws-vpce-operator.yaml.gotmpl
@@ -15,6 +15,8 @@ spec:
     metadata:
       labels:
         name: aws-vpce-operator
+      annotations:
+        openshift.io/required-scc: restricted-v2
     spec:
       serviceAccountName: aws-vpce-operator
       securityContext:
@@ -81,6 +83,7 @@ spec:
           periodSeconds: 10
         securityContext:
           allowPrivilegeEscalation: false
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - name: openshift-sa-token
           mountPath: /var/run/secrets/openshift/serviceaccount

--- a/pkg/aws_client/route53_hosted_zone.go
+++ b/pkg/aws_client/route53_hosted_zone.go
@@ -19,11 +19,12 @@ package aws_client
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/route53"
 	"github.com/aws/aws-sdk-go-v2/service/route53/types"
 	"github.com/openshift/aws-vpce-operator/pkg/util"
-	"time"
 )
 
 // GetDefaultPrivateHostedZoneId returns the cluster's Route53 private hosted zone

--- a/pkg/aws_client/security_group.go
+++ b/pkg/aws_client/security_group.go
@@ -103,7 +103,7 @@ func (c *AWSClient) FilterSecurityGroupById(ctx context.Context, groupId string)
 		var ae smithy.APIError
 		if errors.As(err, &ae) {
 			if ae.ErrorCode() == "InvalidGroup.NotFound" {
-				return nil, nil
+				return nil, nil //nolint:nilnil
 			}
 		}
 		return nil, err

--- a/pkg/aws_client/subnet.go
+++ b/pkg/aws_client/subnet.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"

--- a/pkg/aws_client/tags.go
+++ b/pkg/aws_client/tags.go
@@ -18,6 +18,7 @@ package aws_client
 
 import (
 	"context"
+
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/route53"
 )

--- a/pkg/aws_client/vpc_endpoint.go
+++ b/pkg/aws_client/vpc_endpoint.go
@@ -154,7 +154,7 @@ func (c *AWSClient) DescribeSingleVPCEndpointById(ctx context.Context, id string
 		if errors.As(err, &ae) {
 			// Don't return an error if the VPC endpoint with the specified ID doesn't exist
 			if ae.ErrorCode() == "InvalidVpcEndpointId.NotFound" {
-				return nil, nil
+				return nil, nil //nolint:nilnil
 			}
 		}
 		return nil, err

--- a/pkg/dnses/dnses_test.go
+++ b/pkg/dnses/dnses_test.go
@@ -18,8 +18,9 @@ package dnses
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/aws-vpce-operator/pkg/testutil"

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -56,7 +56,7 @@ func ParseAWSCredentialOverride(ctx context.Context, c client.Reader, region str
 		// https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/credentials/stscreds#hdr-Assume_Role
 		cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
 		if err != nil {
-			return aws.Config{}, fmt.Errorf("failed to build AWS client. Error: %v", err)
+			return aws.Config{}, fmt.Errorf("failed to build AWS client. Error: %w", err)
 		}
 		stsSvc := sts.NewFromConfig(cfg)
 		creds := stscreds.NewAssumeRoleProvider(stsSvc, string(roleArn))


### PR DESCRIPTION
## Summary

- Adds `terminationMessagePolicy: FallbackToLogsOnError` to the operator container spec in both OLM (`deploy/`) and PKO (`deploy_pko/`) deployment manifests
- Adds `openshift.io/required-scc: restricted-v2` annotation to pod template metadata in both deployment manifests
- Fixes lint issues from the golangci-lint v2 config update (nolint directive formatting, import grouping, error wrapping)
- Fixes nil pointer dereference in `generateRoute53Record` where a `(nil, nil)` return could cause a panic in the caller

The `terminationMessagePolicy` and `required-scc` annotation are required for OCP 4.21 conformance. The lint and bug fixes address issues surfaced by the updated golangci-lint v2 config and CodeRabbit review.

**17 files changed** across deployment manifests, controllers, and AWS client packages.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `gofmt` and `goimports` clean
- [ ] Deploy to integration and confirm operator starts correctly
- [ ] Confirm `terminationMessagePolicy` appears in pod spec via `oc get pod -o yaml`
- [ ] Confirm `required-scc` annotation appears in pod metadata

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced OpenShift security requirements by adding restricted security context constraints.
  * Improved error reporting and handling across cloud infrastructure operations.
  * Code quality improvements including linting refinements and import organization.
  * Updated termination message handling for better error diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->