### PR TITLE
SREP-4358: improve observability for VpcEndpoint cleanup during deletion

### DIFF
--- a/controllers/vpcendpoint/cleanup.go
+++ b/controllers/vpcendpoint/cleanup.go
@@ -24,6 +24,7 @@ import (
 	route53Types "github.com/aws/aws-sdk-go-v2/service/route53/types"
 	"github.com/aws/smithy-go"
 	configv1 "github.com/openshift/api/config/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,6 +35,18 @@ import (
 
 // cleanupAwsResources cleans up AWS resources associated with a VPC Endpoint.
 func (r *VpcEndpointReconciler) cleanupAwsResources(ctx context.Context, resource *avov1alpha2.VpcEndpoint) error {
+	r.log.V(0).Info("Starting AWS resource cleanup",
+		"vpcEndpoint", resource.Name,
+		"namespace", resource.Namespace,
+		"vpceId", resource.Status.VPCEndpointId,
+		"securityGroupId", resource.Status.SecurityGroupId,
+		"hostedZoneId", resource.Status.HostedZoneId,
+		"resourceRecordSet", resource.Status.ResourceRecordSet,
+	)
+	r.Recorder.Eventf(resource, corev1.EventTypeNormal, "CleanupStarted",
+		"Starting cleanup of AWS resources (vpceId=%s, sgId=%s, hzId=%s)",
+		resource.Status.VPCEndpointId, resource.Status.SecurityGroupId, resource.Status.HostedZoneId)
+
 	if meta.IsStatusConditionTrue(resource.Status.Conditions, avov1alpha2.AWSRoute53RecordCondition) {
 		// Ensure .status.hostedZoneId is populated
 		if err := r.validateR53PrivateHostedZone(ctx, resource); err != nil {
@@ -80,6 +93,8 @@ func (r *VpcEndpointReconciler) cleanupAwsResources(ctx context.Context, resourc
 				r.log.V(0).Error(err, "failed to update status")
 				return err
 			}
+
+			r.Recorder.Eventf(resource, corev1.EventTypeNormal, "Deleted", "Deleted Route53 record(s) in hosted zone %s", resource.Status.HostedZoneId)
 		}
 	}
 
@@ -102,7 +117,8 @@ func (r *VpcEndpointReconciler) cleanupAwsResources(ctx context.Context, resourc
 					if errors.As(err, &ae) {
 						switch ae.ErrorCode() {
 						case new(route53Types.NoSuchHostedZone).ErrorCode():
-							// If there's no such hosted zone, then it's already been deleted
+							r.log.V(0).Info("Route53 hosted zone already deleted", "hostedZoneId", resource.Status.HostedZoneId)
+							r.Recorder.Eventf(resource, corev1.EventTypeNormal, "Deleted", "Route53 hosted zone already deleted: %s", resource.Status.HostedZoneId)
 							resource.Status.HostedZoneId = ""
 							if err := r.Status().Update(ctx, resource); err != nil {
 								r.log.V(0).Error(err, "failed to update status")
@@ -131,6 +147,9 @@ func (r *VpcEndpointReconciler) cleanupAwsResources(ctx context.Context, resourc
 									}
 								}
 							}
+
+							r.log.V(0).Info("Cleared remaining records from Route53 hosted zone, will retry zone deletion", "hostedZoneId", resource.Status.HostedZoneId)
+							r.Recorder.Eventf(resource, corev1.EventTypeNormal, "CleanupProgress", "Cleared remaining records from hosted zone %s, will retry zone deletion", resource.Status.HostedZoneId)
 						default:
 							return err
 						}
@@ -138,6 +157,9 @@ func (r *VpcEndpointReconciler) cleanupAwsResources(ctx context.Context, resourc
 						// Shouldn't happen
 						return fmt.Errorf("unexpected error while deleting hosted zone: %v", err)
 					}
+				} else {
+					r.log.V(0).Info("Deleted Route53 hosted zone", "hostedZoneId", resource.Status.HostedZoneId)
+					r.Recorder.Eventf(resource, corev1.EventTypeNormal, "Deleted", "Deleted Route53 hosted zone: %s", resource.Status.HostedZoneId)
 				}
 			}
 		}
@@ -148,11 +170,14 @@ func (r *VpcEndpointReconciler) cleanupAwsResources(ctx context.Context, resourc
 			return err
 		}
 
-		r.log.V(0).Info("Deleting AWS resources", "VpcEndpoint", resource.Status.VPCEndpointId)
-		if _, err := r.awsClient.DeleteVPCEndpoint(ctx, resource.Status.VPCEndpointId); err != nil {
+		vpceId := resource.Status.VPCEndpointId
+		r.log.V(0).Info("Deleting VPC endpoint", "vpceId", vpceId)
+		if _, err := r.awsClient.DeleteVPCEndpoint(ctx, vpceId); err != nil {
 			var ae smithy.APIError
 			if errors.As(err, &ae) {
 				if ae.ErrorCode() == "InvalidVpcEndpoint.NotFound" {
+					r.log.V(0).Info("VPC endpoint already deleted", "vpceId", vpceId)
+					r.Recorder.Eventf(resource, corev1.EventTypeNormal, "Deleted", "VPC endpoint already deleted: %s", vpceId)
 					resource.Status.VPCEndpointId = ""
 				} else {
 					return err
@@ -161,6 +186,8 @@ func (r *VpcEndpointReconciler) cleanupAwsResources(ctx context.Context, resourc
 				// Shouldn't happen
 				return fmt.Errorf("unexpected error while deleting VPC Endpoint: %v", err)
 			}
+		} else {
+			r.Recorder.Eventf(resource, corev1.EventTypeNormal, "Deleted", "Deleted VPC endpoint: %s", vpceId)
 		}
 
 		resource.Status.Status = "deleting"
@@ -171,11 +198,14 @@ func (r *VpcEndpointReconciler) cleanupAwsResources(ctx context.Context, resourc
 	}
 
 	if resource.Status.SecurityGroupId != "" {
-		r.log.V(0).Info("Deleting AWS resources", "SecurityGroup", resource.Status.SecurityGroupId)
-		if _, err := r.awsClient.DeleteSecurityGroup(ctx, resource.Status.SecurityGroupId); err != nil {
+		sgId := resource.Status.SecurityGroupId
+		r.log.V(0).Info("Deleting security group", "securityGroupId", sgId)
+		if _, err := r.awsClient.DeleteSecurityGroup(ctx, sgId); err != nil {
 			var ae smithy.APIError
 			if errors.As(err, &ae) {
 				if ae.ErrorCode() == "InvalidGroup.NotFound" {
+					r.log.V(0).Info("Security group already deleted", "securityGroupId", sgId)
+					r.Recorder.Eventf(resource, corev1.EventTypeNormal, "Deleted", "Security group already deleted: %s", sgId)
 					resource.Status.SecurityGroupId = ""
 					if err := r.Status().Update(ctx, resource); err != nil {
 						r.log.V(0).Error(err, "failed to update status")
@@ -188,10 +218,13 @@ func (r *VpcEndpointReconciler) cleanupAwsResources(ctx context.Context, resourc
 				// Shouldn't happen
 				return fmt.Errorf("unexpected error while deleting security group: %v", err)
 			}
+		} else {
+			r.Recorder.Eventf(resource, corev1.EventTypeNormal, "Deleted", "Deleted security group: %s", sgId)
 		}
 	}
 
-	r.log.V(0).Info("AWS cleanup complete")
+	r.log.V(0).Info("AWS cleanup complete", "vpcEndpoint", resource.Name, "namespace", resource.Namespace)
+	r.Recorder.Event(resource, corev1.EventTypeNormal, "CleanupComplete", "All AWS resources cleaned up successfully")
 	return nil
 }
 

--- a/controllers/vpcendpoint/cleanup_test.go
+++ b/controllers/vpcendpoint/cleanup_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
 )
 
 func TestVpcEndpointReconciler_cleanupAwsResources(t *testing.T) {
@@ -83,6 +84,7 @@ func TestVpcEndpointReconciler_cleanupAwsResources(t *testing.T) {
 			r := &VpcEndpointReconciler{
 				Client:      client,
 				Scheme:      client.Scheme(),
+				Recorder:    record.NewFakeRecorder(10),
 				awsClient:   aws_client.NewMockedAwsClientWithSubnets(),
 				log:         testr.New(t),
 				clusterInfo: &clusterInfo{},

--- a/controllers/vpcendpoint/metrics.go
+++ b/controllers/vpcendpoint/metrics.go
@@ -45,8 +45,19 @@ var (
 			"action",
 		},
 	)
+
+	vpceCleanupFailure = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "aws_vpce_operator",
+			Name:      "vpce_cleanup_failure_total",
+			Help:      "Count of VPC Endpoint cleanup failures during deletion, labeled by error type",
+		},
+		[]string{
+			"error_type",
+		},
+	)
 )
 
 func init() {
-	metrics.Registry.MustRegister(vpcePendingAcceptance, awsUnauthorizedOperation)
+	metrics.Registry.MustRegister(vpcePendingAcceptance, awsUnauthorizedOperation, vpceCleanupFailure)
 }

--- a/controllers/vpcendpoint/vpcendpoint_controller.go
+++ b/controllers/vpcendpoint/vpcendpoint_controller.go
@@ -108,12 +108,27 @@ func (r *VpcEndpointReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 					// VPC Endpoints take a bit of time to delete, so if there's a dependency error,
 					// we'll requeue the item, so we can try again later.
 					if ae.ErrorCode() == "DependencyViolation" {
-						r.log.V(0).Info("AWS dependency violation, requeueing", "error", ae.ErrorMessage())
+						r.log.V(0).Info("AWS dependency violation, requeueing",
+							"vpcEndpoint", vpce.Name,
+							"namespace", vpce.Namespace,
+							"error", ae.ErrorMessage(),
+						)
+						r.Recorder.Eventf(vpce, corev1.EventTypeWarning, "CleanupBlocked",
+							"AWS dependency violation during cleanup, retrying in 30s: %s", ae.ErrorMessage())
+						vpceCleanupFailure.WithLabelValues("DependencyViolation").Inc()
 						return ctrl.Result{RequeueAfter: time.Second * 30}, nil
 					}
 
 					awsUnauthorizedOperationMetricHandler(err)
 				}
+
+				r.log.V(0).Error(err, "Failed to clean up AWS resources",
+					"vpcEndpoint", vpce.Name,
+					"namespace", vpce.Namespace,
+				)
+				r.Recorder.Eventf(vpce, corev1.EventTypeWarning, "CleanupFailed",
+					"Failed to clean up AWS resources: %v", err)
+				vpceCleanupFailure.WithLabelValues("Error").Inc()
 
 				// Catch other errors and retry
 				return ctrl.Result{}, err


### PR DESCRIPTION
## Summary

- Add Kubernetes events throughout the VpcEndpoint deletion path (CleanupStarted, Deleted, CleanupComplete, CleanupBlocked, CleanupFailed) so cleanup progress and failures are visible via `oc get events`
- Add structured "Starting AWS resource cleanup" log with all AWS resource IDs (vpceId, sgId, hostedZoneId) for log correlation
- Log when AWS resources are already deleted (NotFound cases) instead of silently clearing status
- Add `aws_vpce_operator_vpce_cleanup_failure_total` Prometheus counter metric labeled by error_type (DependencyViolation, Error) -- kept low-cardinality intentionally, per-resource detail is in events and logs

Jira: https://redhat.atlassian.net/browse/SREP-4358

## Test plan

- [ ] Unit tests pass (`go test ./controllers/vpcendpoint/...`)
- [ ] Full test suite passes (`go test ./...`)
- [ ] Deploy to a test cluster and delete a VpcEndpoint CR, verify events appear via `oc get events`
- [ ] Verify cleanup failure metric is exposed at the /metrics endpoint