### PR TITLE
SREP-4417: Add Prow e2e Containerfile for CI testing

### DIFF
--- a/test/e2e/Containerfile.prow
+++ b/test/e2e/Containerfile.prow
@@ -1,0 +1,12 @@
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.22 AS builder
+
+WORKDIR /build
+ENV GOFLAGS=""
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go test ./test/e2e -v -c --tags=osde2e -o /e2e.test
+
+FROM registry.ci.openshift.org/ci/rosa-aws-cli:latest
+
+COPY --from=builder /e2e.test /usr/local/bin/e2e.test

--- a/test/e2e/prow-gate-template.yml
+++ b/test/e2e/prow-gate-template.yml
@@ -30,12 +30,13 @@ objects:
           restartPolicy: Never
           containers:
             - name: poll-prow
-              image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+              image: registry.access.redhat.com/ubi9-minimal:9.5
               command:
                 - /bin/bash
                 - -c
                 - |
                   set -euo pipefail
+                  microdnf install -y jq > /dev/null 2>&1
 
                   GCS_BASE="https://storage.googleapis.com/test-platform-results"
                   JOB_NAME="${PROW_JOB_NAME}"
@@ -50,7 +51,6 @@ objects:
 
                   elapsed=0
                   while [[ ${elapsed} -lt ${TIMEOUT} ]]; do
-                    # Get latest build ID
                     build_id=$(curl -sf --max-time 10 "${GCS_BASE}/logs/${JOB_NAME}/latest-build.txt" 2>/dev/null || true)
                     if [[ -z "${build_id}" ]]; then
                       echo "No builds found yet, waiting..."
@@ -59,7 +59,6 @@ objects:
                       continue
                     fi
 
-                    # Check the prowjob metadata for commit SHA
                     prowjob=$(curl -sf --max-time 10 "${GCS_BASE}/logs/${JOB_NAME}/${build_id}/prowjob.json" 2>/dev/null || true)
                     if [[ -z "${prowjob}" ]]; then
                       echo "Build ${build_id}: no prowjob.json yet, waiting..."
@@ -68,13 +67,8 @@ objects:
                       continue
                     fi
 
-                    # Extract the commit SHA from the prowjob
-                    job_sha=$(echo "${prowjob}" | python3 -c "
-                  import sys, json
-                  pj = json.load(sys.stdin)
-                  refs = pj.get('spec', {}).get('extra_refs', [{}])[0]
-                  print(refs.get('base_sha', '')[:40])
-                  " 2>/dev/null || true)
+                    # Postsubmits use spec.refs.base_sha, periodics use spec.extra_refs[0].base_sha
+                    job_sha=$(echo "${prowjob}" | jq -r '(.spec.refs.base_sha // .spec.extra_refs[0].base_sha // "")[0:40]' 2>/dev/null || true)
 
                     if [[ "${job_sha}" != "${TARGET_SHA}"* ]]; then
                       echo "Build ${build_id}: SHA ${job_sha:0:8} does not match target ${TARGET_SHA:0:8}, waiting..."
@@ -83,7 +77,6 @@ objects:
                       continue
                     fi
 
-                    # SHA matches, check result
                     finished=$(curl -sf --max-time 10 "${GCS_BASE}/logs/${JOB_NAME}/${build_id}/finished.json" 2>/dev/null || true)
                     if [[ -z "${finished}" ]]; then
                       echo "Build ${build_id}: SHA matches, job still running..."
@@ -92,7 +85,7 @@ objects:
                       continue
                     fi
 
-                    result=$(echo "${finished}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('result',''))" 2>/dev/null)
+                    result=$(echo "${finished}" | jq -r '.result // ""')
 
                     if [[ "${result}" == "SUCCESS" ]]; then
                       echo "Build ${build_id}: PASSED for SHA ${TARGET_SHA:0:8}"

--- a/test/e2e/prow-gate-template.yml
+++ b/test/e2e/prow-gate-template.yml
@@ -1,0 +1,121 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: prow-e2e-gate
+parameters:
+  - name: PROW_JOB_NAME
+    value: "branch-ci-openshift-aws-vpce-operator-main-avo-e2e-stage"
+  - name: IMAGE_TAG
+    required: true
+    description: Commit SHA to match against the Prow postsubmit result.
+  - name: POLL_TIMEOUT
+    value: "3600"
+    description: Max seconds to wait for a passing Prow result.
+  - name: POLL_INTERVAL
+    value: "60"
+    description: Seconds between poll attempts.
+  - name: JOBID
+    generate: expression
+    from: "[0-9a-z]{7}"
+objects:
+  - apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: prow-e2e-gate-${IMAGE_TAG}-${JOBID}
+    spec:
+      backoffLimit: 0
+      activeDeadlineSeconds: ${{POLL_TIMEOUT}}
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: poll-prow
+              image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  set -euo pipefail
+
+                  GCS_BASE="https://storage.googleapis.com/test-platform-results"
+                  JOB_NAME="${PROW_JOB_NAME}"
+                  TARGET_SHA="${IMAGE_TAG}"
+                  TIMEOUT="${POLL_TIMEOUT}"
+                  INTERVAL="${POLL_INTERVAL}"
+
+                  echo "Waiting for Prow postsubmit result..."
+                  echo "  Job: ${JOB_NAME}"
+                  echo "  SHA: ${TARGET_SHA}"
+                  echo "  Timeout: ${TIMEOUT}s"
+
+                  elapsed=0
+                  while [[ ${elapsed} -lt ${TIMEOUT} ]]; do
+                    # Get latest build ID
+                    build_id=$(curl -sf --max-time 10 "${GCS_BASE}/logs/${JOB_NAME}/latest-build.txt" 2>/dev/null || true)
+                    if [[ -z "${build_id}" ]]; then
+                      echo "No builds found yet, waiting..."
+                      sleep "${INTERVAL}"
+                      elapsed=$((elapsed + INTERVAL))
+                      continue
+                    fi
+
+                    # Check the prowjob metadata for commit SHA
+                    prowjob=$(curl -sf --max-time 10 "${GCS_BASE}/logs/${JOB_NAME}/${build_id}/prowjob.json" 2>/dev/null || true)
+                    if [[ -z "${prowjob}" ]]; then
+                      echo "Build ${build_id}: no prowjob.json yet, waiting..."
+                      sleep "${INTERVAL}"
+                      elapsed=$((elapsed + INTERVAL))
+                      continue
+                    fi
+
+                    # Extract the commit SHA from the prowjob
+                    job_sha=$(echo "${prowjob}" | python3 -c "
+                  import sys, json
+                  pj = json.load(sys.stdin)
+                  refs = pj.get('spec', {}).get('extra_refs', [{}])[0]
+                  print(refs.get('base_sha', '')[:40])
+                  " 2>/dev/null || true)
+
+                    if [[ "${job_sha}" != "${TARGET_SHA}"* ]]; then
+                      echo "Build ${build_id}: SHA ${job_sha:0:8} does not match target ${TARGET_SHA:0:8}, waiting..."
+                      sleep "${INTERVAL}"
+                      elapsed=$((elapsed + INTERVAL))
+                      continue
+                    fi
+
+                    # SHA matches, check result
+                    finished=$(curl -sf --max-time 10 "${GCS_BASE}/logs/${JOB_NAME}/${build_id}/finished.json" 2>/dev/null || true)
+                    if [[ -z "${finished}" ]]; then
+                      echo "Build ${build_id}: SHA matches, job still running..."
+                      sleep "${INTERVAL}"
+                      elapsed=$((elapsed + INTERVAL))
+                      continue
+                    fi
+
+                    result=$(echo "${finished}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('result',''))" 2>/dev/null)
+
+                    if [[ "${result}" == "SUCCESS" ]]; then
+                      echo "Build ${build_id}: PASSED for SHA ${TARGET_SHA:0:8}"
+                      exit 0
+                    else
+                      echo "Build ${build_id}: FAILED (${result}) for SHA ${TARGET_SHA:0:8}"
+                      exit 1
+                    fi
+                  done
+
+                  echo "Timed out waiting for Prow result for SHA ${TARGET_SHA:0:8}"
+                  exit 1
+              resources:
+                requests:
+                  cpu: "100m"
+                  memory: "128Mi"
+                limits:
+                  cpu: "200m"
+                  memory: "256Mi"
+              securityContext:
+                runAsNonRoot: true
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault


### PR DESCRIPTION
## Summary

- Add Containerfile.prow that builds the e2e test binary on rosa-aws-cli base image
- Provides both the Ginkgo e2e binary and OCM/backplane CLI tools in a single image
- Used by the Prow step registry to run operator e2e tests against ephemeral ROSA clusters

## Context

Part of the operator e2e Prow migration ([SREP-4417](https://redhat.atlassian.net/browse/SREP-4417)). This image is consumed by ci-operator in the companion openshift/release PR which adds the step registry workflow and periodic job config.

## Jira

- https://redhat.atlassian.net/browse/SREP-4417

[SREP-4417]: https://redhat.atlassian.net/browse/SREP-4417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a containerized build for end-to-end tests to standardize packaging and execution of E2E binaries.
  * Added an OpenShift template for a gating job that polls CI artifacts, waits for the target commit’s E2E run, and gates pipeline progress based on the run’s final success (with configurable polling timeout/interval and unique job naming).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->