### PR TITLE
Fix e2e tests failing in osde2e container (missing go.mod)

### DIFF
--- a/test/e2e/aws_vpce_operator_tests.go
+++ b/test/e2e/aws_vpce_operator_tests.go
@@ -64,6 +64,8 @@ var _ = BeforeSuite(func(ctx context.Context) {
 	if !isOperatorRunning() {
 		if repoRoot := findRepoRootOrEmpty(); repoRoot != "" {
 			startOperator(repoRoot)
+		} else {
+			By("Skipping local operator start: repository root not found, assuming operator pre-deployed")
 		}
 	}
 

--- a/test/e2e/aws_vpce_operator_tests.go
+++ b/test/e2e/aws_vpce_operator_tests.go
@@ -58,9 +58,13 @@ var _ = BeforeSuite(func(ctx context.Context) {
 	_, err = applyCRDYaml(ctx, c, crds.VpcEndpointTemplateCRD)
 	Expect(err).ToNot(HaveOccurred(), "failed to apply VpcEndpointTemplate CRD")
 
-	// Build and start the operator if not already running
+	// Build and start the operator if not already running.
+	// In containerized environments (e.g., osde2e), the operator is pre-deployed
+	// to the cluster and source code is not available, so skip building from source.
 	if !isOperatorRunning() {
-		startOperator()
+		if repoRoot := findRepoRootOrEmpty(); repoRoot != "" {
+			startOperator(repoRoot)
+		}
 	}
 
 	DeferCleanup(func(ctx context.Context) {
@@ -82,9 +86,8 @@ func isOperatorRunning() bool {
 }
 
 // startOperator builds and starts the operator as a subprocess.
-func startOperator() {
+func startOperator(repoRoot string) {
 	By("building the operator binary")
-	repoRoot := findRepoRoot()
 	binaryPath := filepath.Join(repoRoot, "build", "aws-vpce-operator-test")
 
 	buildCmd := exec.Command("go", "build", "-o", binaryPath, "./main.go")
@@ -147,22 +150,26 @@ func stopOperator() {
 	operatorCmd = nil
 
 	// Clean up the test binary
-	repoRoot := findRepoRoot()
-	_ = os.Remove(filepath.Join(repoRoot, "build", "aws-vpce-operator-test"))
+	if repoRoot := findRepoRootOrEmpty(); repoRoot != "" {
+		_ = os.Remove(filepath.Join(repoRoot, "build", "aws-vpce-operator-test"))
+	}
 }
 
-// findRepoRoot walks up from the current working directory to find the repo root
-// by looking for go.mod.
-func findRepoRoot() string {
+// findRepoRootOrEmpty walks up from the current working directory to find the
+// repo root by looking for go.mod. Returns an empty string if no go.mod is found
+// (e.g., when running inside a container image).
+func findRepoRootOrEmpty() string {
 	dir, err := os.Getwd()
-	Expect(err).ToNot(HaveOccurred())
+	if err != nil {
+		return ""
+	}
 	for {
 		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
 			return dir
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			Fail("could not find repo root (no go.mod found)")
+			return ""
 		}
 		dir = parent
 	}


### PR DESCRIPTION
## Summary
- PR #375 introduced `startOperator()` which calls `findRepoRoot()` to locate `go.mod` and build the operator from source. In the osde2e container image, only the compiled test binary exists — no source code, `go.mod`, or Go toolchain — causing BeforeSuite to fail immediately with `could not find repo root (no go.mod found)`.
- Replace `findRepoRoot()` (which calls `Fail()`) with `findRepoRootOrEmpty()` (which returns `""`) and skip the operator build/start when running inside a container where the operator is already pre-deployed to the cluster.

## Test plan
- [ ] Verify `make osde2e` still builds the test binary successfully
- [ ] Verify local e2e tests still build and start the operator from source when `go.mod` is present
- [ ] Verify osde2e nightly jobs no longer fail with "could not find repo root (no go.mod found)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined the operator startup flow in end-to-end tests to conditionally compile from source only when required environmental prerequisites are available.
  * Enhanced test cleanup procedures to be more robust, safely handling scenarios where prerequisites are unavailable.
  * Improved the prerequisite discovery mechanism to gracefully handle missing environment configurations instead of failing test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->