### PR TITLE
Skip AWS integration tests when operator is not deployed

### DIFF
--- a/test/e2e/aws_integration_test.go
+++ b/test/e2e/aws_integration_test.go
@@ -22,25 +22,35 @@ import (
 
 var _ = Describe("aws-vpce-operator AWS integration", func() {
 	var (
-		helper *awsTestHelper
-		ns     string
+		helper           *awsTestHelper
+		ns               string
+		operatorDeployed *bool
 	)
 
 	BeforeEach(func(ctx context.Context) {
-		if operatorCmd == nil && !isOperatorRunning() {
-			dep := &unstructured.Unstructured{}
-			dep.SetGroupVersionKind(schema.GroupVersionKind{
-				Group:   "apps",
-				Version: "v1",
-				Kind:    "Deployment",
-			})
-			err := c.Get(ctx, client.ObjectKey{
-				Name:      "aws-vpce-operator",
-				Namespace: "openshift-aws-vpce-operator",
-			}, dep)
-			if err != nil {
-				Skip("aws-vpce-operator deployment not found in openshift-aws-vpce-operator namespace")
+		if operatorDeployed == nil {
+			deployed := operatorCmd != nil || isOperatorRunning()
+			if !deployed {
+				dep := &unstructured.Unstructured{}
+				dep.SetGroupVersionKind(schema.GroupVersionKind{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Deployment",
+				})
+				err := c.Get(ctx, client.ObjectKey{
+					Name:      "aws-vpce-operator",
+					Namespace: "openshift-aws-vpce-operator",
+				}, dep)
+				if err == nil {
+					deployed = true
+				} else if !kerr.IsNotFound(err) {
+					Expect(err).ToNot(HaveOccurred(), "failed to check for operator deployment")
+				}
 			}
+			operatorDeployed = &deployed
+		}
+		if !*operatorDeployed {
+			Skip("aws-vpce-operator deployment not found in openshift-aws-vpce-operator namespace")
 		}
 
 		helper = newAWSTestHelper(ctx, c)

--- a/test/e2e/aws_integration_test.go
+++ b/test/e2e/aws_integration_test.go
@@ -15,6 +15,8 @@ import (
 	kerr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -25,6 +27,22 @@ var _ = Describe("aws-vpce-operator AWS integration", func() {
 	)
 
 	BeforeEach(func(ctx context.Context) {
+		if operatorCmd == nil && !isOperatorRunning() {
+			dep := &unstructured.Unstructured{}
+			dep.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "apps",
+				Version: "v1",
+				Kind:    "Deployment",
+			})
+			err := c.Get(ctx, client.ObjectKey{
+				Name:      "aws-vpce-operator",
+				Namespace: "openshift-aws-vpce-operator",
+			}, dep)
+			if err != nil {
+				Skip("aws-vpce-operator deployment not found in openshift-aws-vpce-operator namespace")
+			}
+		}
+
 		helper = newAWSTestHelper(ctx, c)
 		ns = "default"
 	})


### PR DESCRIPTION
## Summary
- The AWS integration tests (PR #375) require a running operator to reconcile VpcEndpoint CRs. Before PR #375, the e2e suite only contained CEL validation tests (dry-run schema checks) that don't need the operator.
- On non-Private Link clusters in osde2e, the operator isn't deployed via SelectorSyncSet, so the integration tests poll for up to 10 minutes each waiting for reconciliation that never happens, exhausting the 30-minute executor timeout.
- Adds a `BeforeEach` check for the `aws-vpce-operator` Deployment in `openshift-aws-vpce-operator`. When neither a local operator subprocess nor a cluster-deployed operator is found, the integration tests are skipped. CEL validation tests continue to run everywhere.

## Future improvement
An osde2e job targeting a Private Link cluster would allow the integration tests to run in CI against a real operator deployment — currently they can only be exercised in local development.

## Test plan
- [ ] Verify e2e suite completes on a non-Private Link cluster (integration tests skipped, CEL tests pass)
- [ ] Verify local development (`make run` + e2e) still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Tests now skip gracefully when the required operator deployment is unavailable, improving test reliability and preventing false failures in environments without the operator.
  * Added automatic availability checks during test setup to verify proper cluster and operator state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->