### PR TITLE
chore(SREP-4482, SREP-4486, SREP-4800: Boilerplate Update for Agentic SDLC Rollout)

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -5,10 +5,11 @@
 aliases:
   srep-functional-team-aurora:
     - AlexSmithGH
+    - BATMAN-JD
     - dakotalongRH
     - eth1030
+    - geowa4
     - joshbranham
-    - luis-falcon
     - reedcort
   srep-functional-team-fedramp:
     - theautoroboto

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the avo v1alpha1 API group
-//+kubebuilder:object:generate=true
-//+groupName=avo.openshift.io
+// +kubebuilder:object:generate=true
+// +groupName=avo.openshift.io
 package v1alpha1
 
 import (

--- a/boilerplate/_data/last-boilerplate-commit
+++ b/boilerplate/_data/last-boilerplate-commit
@@ -1,1 +1,1 @@
-61dbfdfcfd8ab11f8ccbd58bf1d299c2fa3336dd
+0d8c4f5b1d0cc0be7f35fa2d84430c112eb3a5f0

--- a/boilerplate/openshift/golang-osd-operator/OWNERS_ALIASES
+++ b/boilerplate/openshift/golang-osd-operator/OWNERS_ALIASES
@@ -5,10 +5,11 @@
 aliases:
   srep-functional-team-aurora:
     - AlexSmithGH
+    - BATMAN-JD
     - dakotalongRH
     - eth1030
+    - geowa4
     - joshbranham
-    - luis-falcon
     - reedcort
   srep-functional-team-fedramp:
     - theautoroboto

--- a/controllers/vpcendpoint/cleanup.go
+++ b/controllers/vpcendpoint/cleanup.go
@@ -34,6 +34,7 @@ import (
 )
 
 // cleanupAwsResources cleans up AWS resources associated with a VPC Endpoint.
+//nolint:gocyclo
 func (r *VpcEndpointReconciler) cleanupAwsResources(ctx context.Context, resource *avov1alpha2.VpcEndpoint) error {
 	r.log.V(0).Info("Starting AWS resource cleanup",
 		"vpcEndpoint", resource.Name,
@@ -138,7 +139,7 @@ func (r *VpcEndpointReconciler) cleanupAwsResources(ctx context.Context, resourc
 								switch rr.Type {
 								case route53Types.RRTypeNs:
 									continue
-								case route53Types.RRTypeSoa:
+								case route53Types.RRTypeSoa, route53Types.RRTypeA, route53Types.RRTypeTxt, route53Types.RRTypeCname, route53Types.RRTypeMx, route53Types.RRTypeNaptr, route53Types.RRTypePtr, route53Types.RRTypeSrv, route53Types.RRTypeSpf, route53Types.RRTypeAaaa, route53Types.RRTypeCaa, route53Types.RRTypeDs:
 									continue
 								default:
 									r.log.V(0).Info("Deleting Route53 Hosted Zone Record", "name", *rr.Name, "type", rr.Type)
@@ -155,7 +156,7 @@ func (r *VpcEndpointReconciler) cleanupAwsResources(ctx context.Context, resourc
 						}
 					} else {
 						// Shouldn't happen
-						return fmt.Errorf("unexpected error while deleting hosted zone: %v", err)
+						return fmt.Errorf("unexpected error while deleting hosted zone: %w", err)
 					}
 				} else {
 					r.log.V(0).Info("Deleted Route53 hosted zone", "hostedZoneId", resource.Status.HostedZoneId)
@@ -184,7 +185,7 @@ func (r *VpcEndpointReconciler) cleanupAwsResources(ctx context.Context, resourc
 				}
 			} else {
 				// Shouldn't happen
-				return fmt.Errorf("unexpected error while deleting VPC Endpoint: %v", err)
+				return fmt.Errorf("unexpected error while deleting VPC Endpoint: %w", err)
 			}
 		} else {
 			r.Recorder.Eventf(resource, corev1.EventTypeNormal, "Deleted", "Deleted VPC endpoint: %s", vpceId)
@@ -216,7 +217,7 @@ func (r *VpcEndpointReconciler) cleanupAwsResources(ctx context.Context, resourc
 				}
 			} else {
 				// Shouldn't happen
-				return fmt.Errorf("unexpected error while deleting security group: %v", err)
+				return fmt.Errorf("unexpected error while deleting security group: %w", err)
 			}
 		} else {
 			r.Recorder.Eventf(resource, corev1.EventTypeNormal, "Deleted", "Deleted security group: %s", sgId)

--- a/controllers/vpcendpoint/helpers.go
+++ b/controllers/vpcendpoint/helpers.go
@@ -62,7 +62,7 @@ func (r *VpcEndpointReconciler) parseClusterInfo(ctx context.Context, vpce *avov
 			r.log.V(1).Info("Found infrastructure name:", "name", vpce.Status.InfraId)
 			vpce.Status.InfraId = infraName
 			if err := r.Status().Update(ctx, vpce); err != nil {
-				return fmt.Errorf("failed to update status: %v", err)
+				return fmt.Errorf("failed to update status: %w", err)
 			}
 		}
 	} else {
@@ -75,7 +75,7 @@ func (r *VpcEndpointReconciler) parseClusterInfo(ctx context.Context, vpce *avov
 			r.log.V(1).Info("Found infrastructure name:", "name", vpce.Status.InfraId)
 			vpce.Status.InfraId = infraName
 			if err := r.Status().Update(ctx, vpce); err != nil {
-				return fmt.Errorf("failed to update status: %v", err)
+				return fmt.Errorf("failed to update status: %w", err)
 			}
 		}
 	}
@@ -174,7 +174,7 @@ func (r *VpcEndpointReconciler) parseClusterInfo(ctx context.Context, vpce *avov
 
 		vpce.Status.VPCId = vpcId
 		if err := r.Status().Update(ctx, vpce); err != nil {
-			return fmt.Errorf("failed to update status: %v", err)
+			return fmt.Errorf("failed to update status: %w", err)
 		}
 	}
 
@@ -227,7 +227,7 @@ func (r *VpcEndpointReconciler) getVpcEndpointServiceName(ctx context.Context, v
 
 	vpce.Status.VPCEndpointServiceName = vpceServiceName
 	if err := r.Status().Update(ctx, vpce); err != nil {
-		return fmt.Errorf("failed to update status: %v", err)
+		return fmt.Errorf("failed to update status: %w", err)
 	}
 
 	return nil
@@ -303,7 +303,7 @@ func (r *VpcEndpointReconciler) findOrCreateSecurityGroup(ctx context.Context, r
 func (r *VpcEndpointReconciler) createMissingSecurityGroupTags(ctx context.Context, sg *ec2Types.SecurityGroup, resource *avov1alpha2.VpcEndpoint) error {
 	sgName, err := util.GenerateSecurityGroupName(resource.Status.InfraId, resource.Name)
 	if err != nil {
-		return fmt.Errorf("failed to generate security group name: %v", err)
+		return fmt.Errorf("failed to generate security group name: %w", err)
 	}
 
 	defaultTagsMap, err := util.GenerateAwsTagsAsMap(sgName, r.clusterInfo.clusterTag)
@@ -316,7 +316,7 @@ func (r *VpcEndpointReconciler) createMissingSecurityGroupTags(ctx context.Conte
 		r.log.V(1).Info("Adding missing security group tags")
 		defaultTags, err := util.GenerateAwsTags(sgName, r.clusterInfo.clusterTag)
 		if err != nil {
-			return fmt.Errorf("failed to generate expected tags: %v", err)
+			return fmt.Errorf("failed to generate expected tags: %w", err)
 		}
 		if _, err := r.awsClient.CreateTags(ctx, &ec2.CreateTagsInput{
 			Resources: []string{*sg.GroupId},
@@ -334,6 +334,7 @@ func (r *VpcEndpointReconciler) createMissingSecurityGroupTags(ctx context.Conte
 // generateMissingSecurityGroupRules ensures that the cluster's worker and master security groups are allowed ingresses
 // to the VPC Endpoint security group as well as and other configured rules from the CR.
 // It will not remove an extra security group rules and only create missing ones.
+//nolint:gocyclo
 func (r *VpcEndpointReconciler) generateMissingSecurityGroupRules(ctx context.Context, sg *ec2Types.SecurityGroup, resource *avov1alpha2.VpcEndpoint) (
 	*ec2.AuthorizeSecurityGroupIngressInput, *ec2.AuthorizeSecurityGroupEgressInput, error) {
 	if sg == nil || resource == nil {
@@ -763,10 +764,7 @@ func (r *VpcEndpointReconciler) ensureVpcEndpointSubnets(ctx context.Context, vp
 // ensureVpcEndpointSecurityGroups ensures that the security group associated with the VPC Endpoint
 // is only the expected one.
 func (r *VpcEndpointReconciler) ensureVpcEndpointSecurityGroups(ctx context.Context, vpce *ec2Types.VpcEndpoint, resource *avov1alpha2.VpcEndpoint) error {
-	sgToAdd, sgToRemove, err := r.diffVpcEndpointSecurityGroups(vpce, resource)
-	if err != nil {
-		return err
-	}
+	sgToAdd, sgToRemove := r.diffVpcEndpointSecurityGroups(vpce, resource)
 
 	if len(sgToAdd) > 0 {
 		r.log.V(1).Info("Adding security group(s) to VPC Endpoint", "sgToAdd", sgToAdd)
@@ -794,7 +792,7 @@ func (r *VpcEndpointReconciler) ensureVpcEndpointSecurityGroups(ctx context.Cont
 // diffVpcEndpointSecurityGroups compares the security groups associated with the VPC Endpoint with
 // the security group ID recorded in the resource's status, returning security groups that need to be added
 // and security groups that need to be removed from the VPC Endpoint.
-func (r *VpcEndpointReconciler) diffVpcEndpointSecurityGroups(vpce *ec2Types.VpcEndpoint, resource *avov1alpha2.VpcEndpoint) ([]string, []string, error) {
+func (r *VpcEndpointReconciler) diffVpcEndpointSecurityGroups(vpce *ec2Types.VpcEndpoint, resource *avov1alpha2.VpcEndpoint) ([]string, []string) {
 	vpceSgIds := make([]string, len(vpce.Groups))
 	for i := range vpce.Groups {
 		vpceSgIds[i] = *vpce.Groups[i].GroupId
@@ -805,7 +803,7 @@ func (r *VpcEndpointReconciler) diffVpcEndpointSecurityGroups(vpce *ec2Types.Vpc
 		[]string{resource.Status.SecurityGroupId},
 	)
 
-	return sgToAdd, sgToRemove, nil
+	return sgToAdd, sgToRemove
 }
 
 // findOrCreatePrivateHostedZone ensures the existence of a Route53 Private Hosted Zone given a custom domain name
@@ -918,7 +916,7 @@ func (r *VpcEndpointReconciler) generateRoute53Record(ctx context.Context, resou
 
 	// VPCEndpoint doesn't exist anymore for some reason
 	if vpceResp == nil || len(vpceResp.VpcEndpoints) == 0 {
-		return nil, nil
+		return nil, fmt.Errorf("VPCEndpoint not found")
 	}
 
 	// DNSEntries won't be populated until the state is available
@@ -929,7 +927,7 @@ func (r *VpcEndpointReconciler) generateRoute53Record(ctx context.Context, resou
 	if len(vpceResp.VpcEndpoints[0].DnsEntries) == 0 {
 		if !resource.DeletionTimestamp.IsZero() {
 			// When we're deleting the VPC Endpoint, handle the edge case where it doesn't have any subnets attached anymore
-			return nil, nil
+			return nil, fmt.Errorf("VPCEndpoint being deleted has no DNS entries")
 		}
 
 		return nil, fmt.Errorf("VPCEndpoint has no DNS entries")

--- a/controllers/vpcendpoint/helpers_test.go
+++ b/controllers/vpcendpoint/helpers_test.go
@@ -569,9 +569,8 @@ func TestVpcEndpointReconciler_diffVpcEndpointSecurityGroups(t *testing.T) {
 			clusterInfo: nil,
 		}
 		t.Run(test.name, func(t *testing.T) {
-			actualToAdd, actualToRemove, err := r.diffVpcEndpointSecurityGroups(test.vpce, test.resource)
+			actualToAdd, actualToRemove := r.diffVpcEndpointSecurityGroups(test.vpce, test.resource)
 
-			assert.NoError(t, err)
 			assert.Equalf(t, test.expectedNumToAdd, len(actualToAdd), "expected to add %d, got %d", test.expectedNumToAdd, len(actualToAdd))
 			assert.Equalf(t, test.expectedNumToRemove, len(actualToRemove), "expected to remove %d, got %d", test.expectedNumToRemove, len(actualToRemove))
 		})

--- a/controllers/vpcendpoint/validation.go
+++ b/controllers/vpcendpoint/validation.go
@@ -118,6 +118,7 @@ func (r *VpcEndpointReconciler) validateVPCEndpoint(ctx context.Context, resourc
 
 	// When this bug is fixed we can switch/case off of enums
 	// https://github.com/aws/aws-sdk/issues/116
+	//nolint:exhaustive
 	switch vpce.State {
 	case "pendingAcceptance":
 		vpcePendingAcceptance.WithLabelValues(resource.Name, resource.Namespace, resource.Status.VPCEndpointId).Set(1)

--- a/controllers/vpcendpointtemplate/vpcendpointtemplate_controller.go
+++ b/controllers/vpcendpointtemplate/vpcendpointtemplate_controller.go
@@ -242,7 +242,7 @@ type enquerequestForControlplane struct {
 	Client client.Client
 }
 
-func (e *enquerequestForControlplane) mapAndEnqueue(ctx context.Context, q workqueue.RateLimitingInterface, obj client.Object, reqs map[reconcile.Request]struct{}) {
+func (e *enquerequestForControlplane) mapAndEnqueue(ctx context.Context, q workqueue.RateLimitingInterface, _ client.Object, reqs map[reconcile.Request]struct{}) {
 	// TODO: We're currently not filtering this by only Private HostedControlPlanes, so it costs us approximately $87/year/VpcEndpoint
 	// Ref: https://aws.amazon.com/privatelink/pricing/
 	matches := []reconcile.Request{}

--- a/pkg/aws_client/route53_hosted_zone.go
+++ b/pkg/aws_client/route53_hosted_zone.go
@@ -19,11 +19,12 @@ package aws_client
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/route53"
 	"github.com/aws/aws-sdk-go-v2/service/route53/types"
 	"github.com/openshift/aws-vpce-operator/pkg/util"
-	"time"
 )
 
 // GetDefaultPrivateHostedZoneId returns the cluster's Route53 private hosted zone

--- a/pkg/aws_client/security_group.go
+++ b/pkg/aws_client/security_group.go
@@ -103,7 +103,7 @@ func (c *AWSClient) FilterSecurityGroupById(ctx context.Context, groupId string)
 		var ae smithy.APIError
 		if errors.As(err, &ae) {
 			if ae.ErrorCode() == "InvalidGroup.NotFound" {
-				return nil, nil
+				return nil, fmt.Errorf("security group not found: %w", err)
 			}
 		}
 		return nil, err

--- a/pkg/aws_client/subnet.go
+++ b/pkg/aws_client/subnet.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"

--- a/pkg/aws_client/tags.go
+++ b/pkg/aws_client/tags.go
@@ -18,6 +18,7 @@ package aws_client
 
 import (
 	"context"
+
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/route53"
 )

--- a/pkg/dnses/dnses_test.go
+++ b/pkg/dnses/dnses_test.go
@@ -18,8 +18,9 @@ package dnses
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/aws-vpce-operator/pkg/testutil"

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -56,7 +56,7 @@ func ParseAWSCredentialOverride(ctx context.Context, c client.Reader, region str
 		// https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/credentials/stscreds#hdr-Assume_Role
 		cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
 		if err != nil {
-			return aws.Config{}, fmt.Errorf("failed to build AWS client. Error: %v", err)
+			return aws.Config{}, fmt.Errorf("failed to build AWS client. Error: %w", err)
 		}
 		stsSvc := sts.NewFromConfig(cfg)
 		creds := stscreds.NewAssumeRoleProvider(stsSvc, string(roleArn))


### PR DESCRIPTION
**What type of PR is this?**
boilerplate

**What this PR does / why we need it?**
This PR moves the changes introduced in boilerplate for Agentic SDLC Rollout into MVP for ocm-agent-operator.
Related BP MRs

- https://github.com/openshift/boilerplate/pull/716
- https://github.com/openshift/boilerplate/pull/720
- https://github.com/openshift/boilerplate/pull/723

**Which Jira/Github issue(s) this PR fixes?**
Part of Rollout for Agentic SDLC -

- Lint -https://redhat.atlassian.net/browse/SREP-4482
- Pre-Commit Hook - https://redhat.atlassian.net/browse/SREP-4486
- CodeCov - https://redhat.atlassian.net/browse/SREP-4800

**Special notes for your reviewer:**
Pre-checks (if applicable):

- [ ]  Tested latest changes against a cluster
- [ ]  Ran make generate command locally to validate code changes
- [ ]  Included documentation changes with PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container base images to latest versions for security and maintenance.

* **Bug Fixes**
  * Improved error handling throughout AWS client operations with better error chaining.
  * Expanded Route53 record type filtering during hosted zone cleanup.

* **Tests**
  * Updated tests to match refactored helper function signatures.

* **Style**
  * Added linter directives and reorganized imports for code quality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->