### PR TITLE
Add Dependabot auto-merge workflows (ROSA-745)

### DIFF
--- a/.github/workflows/branch-protection-check.yml
+++ b/.github/workflows/branch-protection-check.yml
@@ -1,0 +1,91 @@
+name: Branch Protection Check
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # Every Monday at 9 AM UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify-config:
+    name: Verify Dependabot and auto-merge setup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Validate Dependabot and workflow configuration
+        run: |
+          set -euo pipefail
+          pip install --quiet pyyaml
+          python3 <<'PY'
+          import sys
+          from pathlib import Path
+
+          import yaml
+
+          def fail(msg: str) -> None:
+              print(f"❌ {msg}")
+              sys.exit(1)
+
+          dependabot_path = Path(".github/dependabot.yml")
+          if not dependabot_path.is_file():
+              fail("Dependabot configuration missing (.github/dependabot.yml)")
+
+          with dependabot_path.open() as f:
+              cfg = yaml.safe_load(f)
+          if not isinstance(cfg, dict):
+              fail("dependabot.yml must be a YAML mapping")
+          if cfg.get("version") != 2:
+              fail("dependabot.yml: version must be 2")
+          updates = cfg.get("updates")
+          if not isinstance(updates, list) or not updates:
+              fail("dependabot.yml: updates must be a non-empty list")
+          for i, entry in enumerate(updates):
+              if not isinstance(entry, dict):
+                  fail(f"dependabot.yml: updates[{i}] must be a mapping")
+              if not entry.get("package-ecosystem"):
+                  fail(f"dependabot.yml: updates[{i}] missing package-ecosystem")
+              if "directory" not in entry:
+                  fail(f"dependabot.yml: updates[{i}] missing directory")
+
+          print("✅ dependabot.yml structure is valid")
+          for entry in updates:
+              print(f"   - {entry.get('package-ecosystem')} ({entry.get('directory')})")
+
+          workflow_path = Path(".github/workflows/dependabot-auto-merge.yml")
+          if not workflow_path.is_file():
+              fail("dependabot-auto-merge workflow missing")
+
+          with workflow_path.open() as f:
+              wf = yaml.safe_load(f)
+          if not isinstance(wf, dict):
+              fail("dependabot-auto-merge.yml must be a YAML mapping")
+          on = wf.get("on")
+          if not isinstance(on, dict) or "pull_request_target" not in on:
+              fail("dependabot-auto-merge.yml must use pull_request_target trigger")
+          jobs = wf.get("jobs")
+          if not isinstance(jobs, dict) or "auto-merge" not in jobs:
+              fail("dependabot-auto-merge.yml must define jobs.auto-merge")
+          job = jobs["auto-merge"]
+          if not isinstance(job, dict):
+              fail("jobs.auto-merge must be a mapping")
+          steps = job.get("steps")
+          if not isinstance(steps, list) or not steps:
+              fail("jobs.auto-merge must define steps")
+          uses = [
+              s.get("uses", "")
+              for s in steps
+              if isinstance(s, dict)
+          ]
+          if not any("dependabot/fetch-metadata" in u for u in uses):
+              fail("jobs.auto-merge must include dependabot/fetch-metadata")
+
+          print("✅ dependabot-auto-merge.yml structure is valid")
+          print("")
+          print("ℹ️  dependabot-auto-merge.yml enables merge via GraphQL")
+          print("   enablePullRequestAutoMerge; the PR merges only after existing")
+          print("   required status checks pass (e.g. ci/prow/*). No extra CI job.")
+          PY

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,234 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+  checks: read
+  actions: read
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository_owner == 'openshift'
+    steps:
+      - name: Fetch Dependabot Metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable Auto-Merge for Safe Updates
+        id: enable-auto-merge
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        env:
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+          DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}
+          PREVIOUS_VERSION: ${{ steps.metadata.outputs.previous-version }}
+          NEW_VERSION: ${{ steps.metadata.outputs.new-version }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          GH_TOKEN="${{ secrets.GITHUB_TOKEN }}"
+          export GH_TOKEN
+
+          comment_count() {
+            local marker="$1"
+            local http_code
+            http_code=$(curl -sS -w "%{http_code}" -o /tmp/comments-list.json \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              "https://api.github.com/repos/${REPOSITORY}/issues/${PR_NUMBER}/comments")
+            if [[ "$http_code" != "200" ]]; then
+              echo "::warning::Could not list PR comments (HTTP ${http_code})" >&2
+              echo "1"
+              return
+            fi
+            jq --arg m "$marker" '[.[] | select(.body | contains($m))] | length' /tmp/comments-list.json
+          }
+
+          post_issue_comment() {
+            local body="$1"
+            local http_code
+            http_code=$(curl -sS -w "%{http_code}" -o /tmp/comment-response.json \
+              -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              "https://api.github.com/repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              -d "$(jq -n --arg body "$body" '{body: $body}')")
+            if [[ ! "$http_code" =~ ^2 ]]; then
+              echo "❌ Failed to post PR comment. HTTP status: ${http_code}"
+              cat /tmp/comment-response.json
+              echo "::warning::PR comment could not be posted"
+              return 1
+            fi
+          }
+
+          graphql_auto_merge_ok() {
+            local http_code="$1"
+            [[ "$http_code" == "200" ]] || return 1
+            jq -e '(.errors // []) | length == 0' /tmp/response.json >/dev/null 2>&1 || return 1
+            jq -e '.data.enablePullRequestAutoMerge.pullRequest != null' /tmp/response.json >/dev/null 2>&1
+          }
+
+          graphql_error_summary() {
+            jq -c '(.errors // []) | if length > 0 then . else .data end' /tmp/response.json 2>/dev/null || cat /tmp/response.json
+          }
+
+          echo "Enabling auto-merge for ${UPDATE_TYPE} update"
+          echo "Dependency: ${DEPENDENCY_NAMES}"
+
+          pr_http_code=$(curl -sS -w "%{http_code}" -o /tmp/pr-response.json \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/repos/${REPOSITORY}/pulls/${PR_NUMBER}")
+
+          if [[ "$pr_http_code" != "200" ]]; then
+            echo "❌ Failed to fetch PR metadata. HTTP status: ${pr_http_code}"
+            cat /tmp/pr-response.json
+            echo "auto_merge_enabled=false" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+          PR_NODE_ID=$(jq -r '.node_id' /tmp/pr-response.json)
+          if [[ -z "$PR_NODE_ID" || "$PR_NODE_ID" == "null" ]]; then
+            echo "❌ Failed to parse PR node ID from response"
+            cat /tmp/pr-response.json
+            echo "auto_merge_enabled=false" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+          http_code=$(curl -sS -w "%{http_code}" -o /tmp/response.json \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/graphql" \
+            -d "{\"query\":\"mutation { enablePullRequestAutoMerge(input: { pullRequestId: \\\"$PR_NODE_ID\\\", mergeMethod: SQUASH }) { pullRequest { autoMergeRequest { enabledAt } } } }\"}")
+
+          if graphql_auto_merge_ok "$http_code"; then
+            echo "✅ Auto-merge enabled successfully via GraphQL"
+            cat /tmp/response.json
+            echo "auto_merge_enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            api_detail=$(graphql_error_summary)
+            echo "❌ Failed to enable auto-merge. HTTP status: ${http_code}"
+            echo "Response body:"
+            cat /tmp/response.json
+            echo "auto_merge_enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Could not enable auto-merge. PR may need manual review."
+            if [[ "$(comment_count 'Dependabot Auto-Merge Status')" -eq 0 ]]; then
+              failure_body=$(jq -rn \
+                --arg ut "$UPDATE_TYPE" \
+                --arg deps "$DEPENDENCY_NAMES" \
+                --arg prev "$PREVIOUS_VERSION" \
+                --arg new "$NEW_VERSION" \
+                --arg api "$api_detail" \
+                '@text "🤖 **Dependabot Auto-Merge Status**
+
+          This PR meets the criteria for auto-merge but could not be automatically merged.
+
+          **Details:**
+          - Update type: \($ut)
+          - Dependencies: \($deps)
+          - Previous version: \($prev)
+          - New version: \($new)
+          - API response: `\($api)`
+
+          Please review and merge manually if appropriate."')
+              post_issue_comment "$failure_body" || true
+            else
+              echo "Auto-merge status comment already posted; skipping duplicate"
+            fi
+          fi
+
+      - name: Comment on Major Version Updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        env:
+          DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}
+          PREVIOUS_VERSION: ${{ steps.metadata.outputs.previous-version }}
+          NEW_VERSION: ${{ steps.metadata.outputs.new-version }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          GH_TOKEN="${{ secrets.GITHUB_TOKEN }}"
+          export GH_TOKEN
+
+          comments_http=$(curl -sS -w "%{http_code}" -o /tmp/comments-list.json \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/repos/${REPOSITORY}/issues/${PR_NUMBER}/comments")
+          if [[ "$comments_http" != "200" ]]; then
+            echo "::warning::Could not list PR comments (HTTP ${comments_http})" >&2
+            exit 0
+          fi
+          existing=$(jq '[.[] | select(.body | contains("Major Version Update Detected"))] | length' /tmp/comments-list.json)
+
+          if [[ "$existing" -gt 0 ]]; then
+            echo "Major-version notice already posted; skipping duplicate comment"
+            exit 0
+          fi
+
+          major_body=$(jq -rn \
+            --arg deps "$DEPENDENCY_NAMES" \
+            --arg prev "$PREVIOUS_VERSION" \
+            --arg new "$NEW_VERSION" \
+            '@text "🚨 **Major Version Update Detected** 🚨
+
+          This PR contains a major version update that requires manual review:
+          - **Dependency:** \($deps)
+          - **Previous version:** \($prev)
+          - **New version:** \($new)
+
+          Please review the changelog and breaking changes before merging.
+
+          Auto-merge has been **disabled** for this PR."')
+
+          http_code=$(curl -sS -w "%{http_code}" -o /tmp/comment-response.json \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            -d "$(jq -n --arg body "$major_body" '{body: $body}')")
+
+          if [[ ! "$http_code" =~ ^2 ]]; then
+            echo "❌ Failed to post major-version comment. HTTP status: ${http_code}"
+            cat /tmp/comment-response.json
+            echo "::warning::Major-version comment could not be posted"
+          fi
+
+      - name: Log Auto-Merge Decision
+        if: always() && steps.metadata.outcome == 'success'
+        env:
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+          DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          AUTO_MERGE_ENABLED: ${{ steps.enable-auto-merge.outputs.auto_merge_enabled }}
+        run: |
+          echo "Auto-merge decision for PR #${PR_NUMBER}:"
+          echo "- Update type: ${UPDATE_TYPE}"
+          echo "- Dependency: ${DEPENDENCY_NAMES}"
+
+          case "${UPDATE_TYPE}" in
+            version-update:semver-patch|version-update:semver-minor)
+              if [[ "${AUTO_MERGE_ENABLED}" == "true" ]]; then
+                echo "✅ Auto-merge ENABLED (GraphQL mutation succeeded)"
+              elif [[ "${AUTO_MERGE_ENABLED}" == "false" ]]; then
+                echo "❌ Auto-merge NOT enabled (GraphQL mutation failed — see enable step logs)"
+              else
+                echo "⚠️ Auto-merge enable step did not complete (check workflow logs)"
+              fi
+              ;;
+            version-update:semver-major)
+              echo "❌ Auto-merge DISABLED: Major version update"
+              ;;
+            *)
+              echo "❌ Auto-merge DISABLED: Update type not eligible for auto-merge (${UPDATE_TYPE})"
+              ;;
+          esac


### PR DESCRIPTION
## Summary
Dependabot auto-merge for routine updates ([ROSA-745](https://redhat.atlassian.net/browse/ROSA-745) / [ROSAENG-751](https://redhat.atlassian.net/browse/ROSAENG-751)), aligned with openshift/backplane-cli ([SREP-2438](https://redhat.atlassian.net/browse/SREP-2438)).

## Changes
- **dependabot-auto-merge.yml**: auto-merge patch/minor/digest after required CI; majors manual. Uses `pull_request_target` (no PR checkout), validated GraphQL/REST/comment responses.
- **branch-protection-check.yml**: weekly verification of Dependabot config and workflows.

## Notes
- `dependabot[bot]` + `openshift` org only.
- Requires ci/prow/* checks ([DPP-20685](https://redhat.atlassian.net/browse/DPP-20685)).

## Test plan
- [ ] Required CI green
- [ ] Review YAML

Made with [Cursor](https://cursor.com)

[ROSA-745]: https://redhat.atlassian.net/browse/ROSA-745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROSAENG-751]: https://redhat.atlassian.net/browse/ROSAENG-751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SREP-2438]: https://redhat.atlassian.net/browse/SREP-2438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DPP-20685]: https://redhat.atlassian.net/browse/DPP-20685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new scheduled (and manually triggerable) repository configuration verification workflow to validate Dependabot and workflow settings.
  * Added an automated Dependabot handling workflow that fetches metadata, selectively enables auto-merge for safe updates (patch/minor/digest), and posts contextual comments for major-version updates or on failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->