### PR TITLE
Cleanup CatalogSource in PKO migration job

### DIFF
--- a/deploy_pko/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/Cleanup-OLM-Job.yaml
@@ -24,6 +24,7 @@ rules:
       - clusterserviceversions
       - subscriptions
       - operatorgroups
+      - catalogsources
     verbs:
       - list
       - get
@@ -78,6 +79,7 @@ spec:
               oc -n openshift-aws-vpce-operator delete csv -l "operators.coreos.com/aws-vpce-operator.openshift-aws-vpce-operator" || true
               oc -n openshift-aws-vpce-operator delete subscription --all || true
               oc -n openshift-aws-vpce-operator delete operatorgroup --all || true
+              oc -n openshift-aws-vpce-operator delete catalogsource --all || true
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
Ensure the catalogsource is cleaned up as well when migrating to PKO.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced OLM cleanup process to completely remove catalog sources along with other operator lifecycle management resources for comprehensive system cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->